### PR TITLE
fix: remove shebang from npm bin scripts for better compatibility

### DIFF
--- a/packages/cli/bin/cli
+++ b/packages/cli/bin/cli
@@ -1,3 +1,3 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env node
 
 import '../dist/index.js';

--- a/packages/create-zenstack/bin/cli
+++ b/packages/create-zenstack/bin/cli
@@ -1,3 +1,3 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env node
 
 import '../dist/index.js';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated command-line tools to display Node.js warnings by default instead of suppressing them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->