### PR TITLE
refactor: clean up transaction semantics for entity mutation hooks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,6 +4,7 @@ early_access: false
 reviews:
     auto_review:
         enabled: true
+    base_branches: ['dev', 'main']
     sequence_diagrams: false
 chat:
     auto_reply: true

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,5 @@
 ## V3 Alpha Todo
 
-- [ ] Infra
-    - [ ] Dependency injection
 - [ ] CLI
     - [x] generate
     - [x] migrate
@@ -11,7 +9,7 @@
     - [ ] format
     - [x] plugin mechanism
     - [x] built-in plugins
-        - [x] ts
+        - [x] typescript
         - [x] prisma
 - [ ] ZModel
     - [x] Import
@@ -34,10 +32,12 @@
         - [x] Pagination
             - [x] Skip and limit
             - [x] Cursor
-        - [x] Filtering
+        - [ ] Filtering
             - [x] Unique fields
             - [x] Scalar fields
             - [x] Relation fields
+            - [ ] JSON filtering
+            - [ ] Full-text search
         - [x] Sort
             - [x] Scalar fields
             - [x] Relation fields
@@ -46,7 +46,6 @@
             - [x] Sorting
             - [x] Pagination
         - [x] Distinct
-        - [ ] JSON filtering
     - [x] Update
         - [x] Input validation
         - [x] Top-level
@@ -66,10 +65,10 @@
     - [x] Transactions
         - [x] Interactive transaction
         - [x] Sequential transaction
-    - [ ] Extensions
+    - [ ] Extensibility
         - [x] Query builder API
         - [x] Computed fields
-        - [x] Prisma client extension
+        - [x] Plugin
         - [ ] Custom procedures
     - [ ] Misc
         - [x] JSDoc for CRUD methods

--- a/packages/runtime/src/client/client-impl.ts
+++ b/packages/runtime/src/client/client-impl.ts
@@ -7,6 +7,7 @@ import {
     Kysely,
     Log,
     sql,
+    Transaction,
     type KyselyProps,
 } from 'kysely';
 import type { GetModels, ProcedureDef, SchemaDef } from '../schema';
@@ -152,6 +153,12 @@ export class ClientImpl<Schema extends SchemaDef> {
             return this.interactiveTransaction(input, options);
         } else {
             return this.sequentialTransaction(input, options);
+        }
+    }
+
+    forceTransaction() {
+        if (!this.kysely.isTransaction) {
+            this.kysely = new Transaction(this.kyselyProps);
         }
     }
 

--- a/packages/runtime/src/client/crud/operations/base.ts
+++ b/packages/runtime/src/client/crud/operations/base.ts
@@ -22,7 +22,7 @@ import { clone } from '../../../utils/clone';
 import { enumerate } from '../../../utils/enumerate';
 import { extractFields, fieldsToSelectObject } from '../../../utils/object-utils';
 import { NUMERIC_FIELD_TYPES } from '../../constants';
-import type { CRUD } from '../../contract';
+import { TransactionIsolationLevel, type CRUD } from '../../contract';
 import type { FindArgs, SelectIncludeOmit, WhereInput } from '../../crud-types';
 import { InternalError, NotFoundError, QueryError } from '../../errors';
 import type { ToKysely } from '../../query-builder';
@@ -2089,7 +2089,7 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
         } else {
             // otherwise, create a new transaction and execute the callback
             let txBuilder = this.kysely.transaction();
-            txBuilder = txBuilder.setIsolationLevel(isolationLevel ?? 'repeatable read');
+            txBuilder = txBuilder.setIsolationLevel(isolationLevel ?? TransactionIsolationLevel.RepeatableRead);
             return txBuilder.execute(callback);
         }
     }

--- a/packages/runtime/src/client/executor/kysely-utils.ts
+++ b/packages/runtime/src/client/executor/kysely-utils.ts
@@ -1,0 +1,14 @@
+import { invariant } from '@zenstackhq/common-helpers';
+import { type OperationNode, AliasNode, IdentifierNode } from 'kysely';
+
+/**
+ * Strips alias from the node if it exists.
+ */
+export function stripAlias(node: OperationNode) {
+    if (AliasNode.is(node)) {
+        invariant(IdentifierNode.is(node.alias), 'Expected identifier as alias');
+        return { alias: node.alias.name, node: node.node };
+    } else {
+        return { alias: undefined, node };
+    }
+}

--- a/packages/runtime/src/client/executor/zenstack-driver.ts
+++ b/packages/runtime/src/client/executor/zenstack-driver.ts
@@ -79,7 +79,12 @@ export class ZenStackDriver implements Driver {
             this.#txConnections.delete(connection);
             if (callbacks) {
                 for (const callback of callbacks) {
-                    await callback();
+                    try {
+                        await callback();
+                    } catch (err) {
+                        // errors in commit callbacks are logged but do not fail the commit
+                        console.error(`Error executing transaction commit callback: ${err}`);
+                    }
                 }
             }
             return result;

--- a/packages/runtime/src/client/plugin.ts
+++ b/packages/runtime/src/client/plugin.ts
@@ -149,6 +149,20 @@ export type MutationInterceptionFilterResult = {
      * Whether entities should be loaded after the mutation.
      */
     loadAfterMutationEntities?: boolean;
+
+    /**
+     * Whether to run after-mutation hooks within the transaction that performs the mutation.
+     *
+     * If set to `true`, if the mutation already runs inside a transaction, the callbacks are
+     * executed immediately after the mutation within the transaction boundary. If the mutation
+     * is not running inside a transaction, a new transaction is created to run both the mutation
+     * and the callbacks.
+     *
+     * If set to `false`, the callbacks are executed after the mutation transaction is committed.
+     *
+     * Defaults to `false`.
+     */
+    runAfterMutationWithinTransaction?: boolean;
 };
 
 export type BeforeEntityMutationCallback<Schema extends SchemaDef> = (
@@ -165,6 +179,15 @@ export type PluginBeforeEntityMutationArgs<Schema extends SchemaDef> = MutationH
      * true in the return value of {@link RuntimePlugin.mutationInterceptionFilter}.
      */
     entities?: unknown[];
+
+    /**
+     * The ZenStack client you can use to perform additional operations. The database operations initiated
+     * from this client are executed within the same transaction as the mutation if the mutation is running
+     * inside a transaction.
+     *
+     * Mutations initiated from this client will NOT trigger entity mutation hooks to avoid infinite loops.
+     */
+    client: ClientContract<Schema>;
 };
 
 export type PluginAfterEntityMutationArgs<Schema extends SchemaDef> = MutationHooksArgs<Schema> & {
@@ -179,6 +202,14 @@ export type PluginAfterEntityMutationArgs<Schema extends SchemaDef> = MutationHo
      * value of {@link RuntimePlugin.mutationInterceptionFilter}.
      */
     afterMutationEntities?: unknown[];
+
+    /**
+     * The ZenStack client you can use to perform additional operations.
+     * See {@link MutationInterceptionFilterResult.runAfterMutationWithinTransaction} for detailed transaction behavior.
+     *
+     * Mutations initiated from this client will NOT trigger entity mutation hooks to avoid infinite loops.
+     */
+    client: ClientContract<Schema>;
 };
 
 // #endregion

--- a/packages/runtime/test/client-api/name-mapping.test.ts
+++ b/packages/runtime/test/client-api/name-mapping.test.ts
@@ -4,24 +4,84 @@ import type { ClientContract } from '../../src';
 import { schema, type SchemaType } from '../schemas/name-mapping/schema';
 import { createTestClient } from '../utils';
 
-describe('Name mapping tests', () => {
-    let db: ClientContract<SchemaType>;
+const TEST_DB = 'client-api-name-mapper-test';
 
-    beforeEach(async () => {
-        db = await createTestClient(
-            schema,
-            { usePrismaPush: true },
-            path.join(__dirname, '../schemas/name-mapping/schema.zmodel'),
-        );
-    });
+describe.each([{ provider: 'sqlite' as const }, { provider: 'postgresql' as const }])(
+    'Name mapping tests',
+    ({ provider }) => {
+        let db: ClientContract<SchemaType>;
 
-    afterEach(async () => {
-        await db.$disconnect();
-    });
+        beforeEach(async () => {
+            db = await createTestClient(
+                schema,
+                { usePrismaPush: true, provider, dbName: TEST_DB },
+                path.join(__dirname, '../schemas/name-mapping/schema.zmodel'),
+            );
+        });
 
-    it('works with create', async () => {
-        await expect(
-            db.user.create({
+        afterEach(async () => {
+            await db.$disconnect();
+        });
+
+        it('works with create', async () => {
+            await expect(
+                db.user.create({
+                    data: {
+                        email: 'u1@test.com',
+                        posts: {
+                            create: {
+                                title: 'Post1',
+                            },
+                        },
+                    },
+                }),
+            ).resolves.toMatchObject({
+                id: expect.any(Number),
+                email: 'u1@test.com',
+            });
+
+            await expect(
+                db.$qb
+                    .insertInto('User')
+                    .values({
+                        email: 'u2@test.com',
+                    })
+                    .returning(['id', 'email'])
+                    .executeTakeFirst(),
+            ).resolves.toMatchObject({
+                id: expect.any(Number),
+                email: 'u2@test.com',
+            });
+
+            await expect(
+                db.$qb
+                    .insertInto('User')
+                    .values({
+                        email: 'u3@test.com',
+                    })
+                    .returning(['User.id', 'User.email'])
+                    .executeTakeFirst(),
+            ).resolves.toMatchObject({
+                id: expect.any(Number),
+                email: 'u3@test.com',
+            });
+
+            await expect(
+                db.$qb
+                    .insertInto('User')
+                    .values({
+                        email: 'u4@test.com',
+                    })
+                    .returningAll()
+                    .executeTakeFirst(),
+            ).resolves.toMatchObject({
+                id: expect.any(Number),
+                email: 'u4@test.com',
+            });
+        });
+
+        it('works with find', async () => {
+            const user = await db.user.create({
                 data: {
                     email: 'u1@test.com',
                     posts: {
@@ -30,205 +90,150 @@ describe('Name mapping tests', () => {
                         },
                     },
                 },
-            }),
-        ).resolves.toMatchObject({
-            id: expect.any(Number),
-            email: 'u1@test.com',
-        });
+            });
 
-        await expect(
-            db.$qb
-                .insertInto('User')
-                .values({
-                    email: 'u2@test.com',
-                })
-                .returning(['id', 'email'])
-                .executeTakeFirst(),
-        ).resolves.toMatchObject({
-            id: expect.any(Number),
-            email: 'u2@test.com',
-        });
-
-        await expect(
-            db.$qb
-                .insertInto('User')
-                .values({
-                    email: 'u3@test.com',
-                })
-                .returning(['User.id', 'User.email'])
-                .executeTakeFirst(),
-        ).resolves.toMatchObject({
-            id: expect.any(Number),
-            email: 'u3@test.com',
-        });
-
-        await expect(
-            db.$qb
-                .insertInto('User')
-                .values({
-                    email: 'u4@test.com',
-                })
-                .returningAll()
-                .executeTakeFirst(),
-        ).resolves.toMatchObject({
-            id: expect.any(Number),
-            email: 'u4@test.com',
-        });
-    });
-
-    it('works with find', async () => {
-        const user = await db.user.create({
-            data: {
-                email: 'u1@test.com',
-                posts: {
-                    create: {
-                        title: 'Post1',
+            await expect(
+                db.user.findFirst({
+                    where: { email: 'u1@test.com' },
+                    select: {
+                        id: true,
+                        email: true,
+                        posts: { where: { title: { contains: 'Post1' } }, select: { title: true } },
                     },
-                },
-            },
-        });
-
-        await expect(
-            db.user.findFirst({
-                where: { email: 'u1@test.com' },
-                select: {
-                    id: true,
-                    email: true,
-                    posts: { where: { title: { contains: 'Post1' } }, select: { title: true } },
-                },
-            }),
-        ).resolves.toMatchObject({
-            id: expect.any(Number),
-            email: 'u1@test.com',
-            posts: [{ title: 'Post1' }],
-        });
-
-        await expect(
-            db.$qb.selectFrom('User').selectAll().where('email', '=', 'u1@test.com').executeTakeFirst(),
-        ).resolves.toMatchObject({
-            id: expect.any(Number),
-            email: 'u1@test.com',
-        });
-
-        await expect(
-            db.$qb.selectFrom('User').select(['User.email']).where('email', '=', 'u1@test.com').executeTakeFirst(),
-        ).resolves.toMatchObject({
-            email: 'u1@test.com',
-        });
-
-        await expect(
-            db.$qb
-                .selectFrom('User')
-                .select(['email'])
-                .whereRef('email', '=', 'email')
-                .orderBy(['email'])
-                .executeTakeFirst(),
-        ).resolves.toMatchObject({
-            email: 'u1@test.com',
-        });
-
-        await expect(
-            db.$qb
-                .selectFrom('Post')
-                .innerJoin('User', 'User.id', 'Post.authorId')
-                .select(['User.email', 'Post.authorId', 'Post.title'])
-                .whereRef('Post.authorId', '=', 'User.id')
-                .executeTakeFirst(),
-        ).resolves.toMatchObject({
-            authorId: user.id,
-            title: 'Post1',
-        });
-
-        await expect(
-            db.$qb
-                .selectFrom('Post')
-                .select(['id', 'title'])
-                .select((eb) =>
-                    eb.selectFrom('User').select(['email']).whereRef('User.id', '=', 'Post.authorId').as('email'),
-                )
-                .executeTakeFirst(),
-        ).resolves.toMatchObject({
-            id: user.id,
-            title: 'Post1',
-            email: 'u1@test.com',
-        });
-    });
-
-    it('works with update', async () => {
-        const user = await db.user.create({
-            data: {
+                }),
+            ).resolves.toMatchObject({
+                id: expect.any(Number),
                 email: 'u1@test.com',
-                posts: {
-                    create: {
-                        id: 1,
-                        title: 'Post1',
-                    },
-                },
-            },
+                posts: [{ title: 'Post1' }],
+            });
+
+            await expect(
+                db.$qb.selectFrom('User').selectAll().where('email', '=', 'u1@test.com').executeTakeFirst(),
+            ).resolves.toMatchObject({
+                id: expect.any(Number),
+                email: 'u1@test.com',
+            });
+
+            await expect(
+                db.$qb.selectFrom('User').select(['User.email']).where('email', '=', 'u1@test.com').executeTakeFirst(),
+            ).resolves.toMatchObject({
+                email: 'u1@test.com',
+            });
+
+            await expect(
+                db.$qb
+                    .selectFrom('User')
+                    .select(['email'])
+                    .whereRef('email', '=', 'email')
+                    .orderBy(['email'])
+                    .executeTakeFirst(),
+            ).resolves.toMatchObject({
+                email: 'u1@test.com',
+            });
+
+            await expect(
+                db.$qb
+                    .selectFrom('Post')
+                    .innerJoin('User', 'User.id', 'Post.authorId')
+                    .select(['User.email', 'Post.authorId', 'Post.title'])
+                    .whereRef('Post.authorId', '=', 'User.id')
+                    .executeTakeFirst(),
+            ).resolves.toMatchObject({
+                authorId: user.id,
+                title: 'Post1',
+            });
+
+            await expect(
+                db.$qb
+                    .selectFrom('Post')
+                    .select(['id', 'title'])
+                    .select((eb) =>
+                        eb.selectFrom('User').select(['email']).whereRef('User.id', '=', 'Post.authorId').as('email'),
+                    )
+                    .executeTakeFirst(),
+            ).resolves.toMatchObject({
+                id: user.id,
+                title: 'Post1',
+                email: 'u1@test.com',
+            });
         });
 
-        await expect(
-            db.user.update({
-                where: { id: user.id },
+        it('works with update', async () => {
+            const user = await db.user.create({
                 data: {
-                    email: 'u2@test.com',
+                    email: 'u1@test.com',
                     posts: {
-                        update: {
-                            where: { id: 1 },
-                            data: { title: 'Post2' },
+                        create: {
+                            id: 1,
+                            title: 'Post1',
                         },
                     },
                 },
-                include: { posts: true },
-            }),
-        ).resolves.toMatchObject({
-            id: user.id,
-            email: 'u2@test.com',
-            posts: [expect.objectContaining({ title: 'Post2' })],
+            });
+
+            await expect(
+                db.user.update({
+                    where: { id: user.id },
+                    data: {
+                        email: 'u2@test.com',
+                        posts: {
+                            update: {
+                                where: { id: 1 },
+                                data: { title: 'Post2' },
+                            },
+                        },
+                    },
+                    include: { posts: true },
+                }),
+            ).resolves.toMatchObject({
+                id: user.id,
+                email: 'u2@test.com',
+                posts: [expect.objectContaining({ title: 'Post2' })],
+            });
+
+            await expect(
+                db.$qb
+                    .updateTable('User')
+                    .set({ email: (eb) => eb.fn('upper', [eb.ref('email')]) })
+                    .where('email', '=', 'u2@test.com')
+                    .returning(['email'])
+                    .executeTakeFirst(),
+            ).resolves.toMatchObject({ email: 'U2@TEST.COM' });
+
+            await expect(
+                db.$qb.updateTable('User as u').set({ email: 'u3@test.com' }).returningAll().executeTakeFirst(),
+            ).resolves.toMatchObject({ id: expect.any(Number), email: 'u3@test.com' });
         });
 
-        await expect(
-            db.$qb
-                .updateTable('User')
-                .set({ email: (eb) => eb.fn('concat', [eb.ref('email'), eb.val('_updated')]) })
-                .where('email', '=', 'u2@test.com')
-                .returning(['email'])
-                .executeTakeFirst(),
-        ).resolves.toMatchObject({ email: 'u2@test.com_updated' });
-
-        await expect(
-            db.$qb.updateTable('User as u').set({ email: 'u3@test.com' }).returningAll().executeTakeFirst(),
-        ).resolves.toMatchObject({ id: expect.any(Number), email: 'u3@test.com' });
-    });
-
-    it('works with delete', async () => {
-        const user = await db.user.create({
-            data: {
-                email: 'u1@test.com',
-                posts: {
-                    create: {
-                        id: 1,
-                        title: 'Post1',
+        it('works with delete', async () => {
+            const user = await db.user.create({
+                data: {
+                    email: 'u1@test.com',
+                    posts: {
+                        create: {
+                            id: 1,
+                            title: 'Post1',
+                        },
                     },
                 },
-            },
-        });
+            });
 
-        await expect(
-            db.$qb.deleteFrom('Post').where('title', '=', 'Post1').returning(['id', 'title']).executeTakeFirst(),
-        ).resolves.toMatchObject({
-            id: user.id,
-            title: 'Post1',
-        });
+            await expect(
+                db.$qb.deleteFrom('Post').where('title', '=', 'Post1').returning(['id', 'title']).executeTakeFirst(),
+            ).resolves.toMatchObject({
+                id: user.id,
+                title: 'Post1',
+            });
 
-        await expect(
-            db.user.delete({
-                where: { email: 'u1@test.com' },
-                include: { posts: true },
-            }),
-        ).resolves.toMatchObject({
-            email: 'u1@test.com',
-            posts: [],
+            await expect(
+                db.user.delete({
+                    where: { email: 'u1@test.com' },
+                    include: { posts: true },
+                }),
+            ).resolves.toMatchObject({
+                email: 'u1@test.com',
+                posts: [],
+            });
         });
-    });
-});
+    },
+);

--- a/packages/runtime/test/plugin/entity-mutation-hooks.test.ts
+++ b/packages/runtime/test/plugin/entity-mutation-hooks.test.ts
@@ -1,412 +1,844 @@
-import SQLite from 'better-sqlite3';
-import { DeleteQueryNode, InsertQueryNode, SqliteDialect, UpdateQueryNode } from 'kysely';
+import { DeleteQueryNode, InsertQueryNode, UpdateQueryNode } from 'kysely';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { ZenStackClient, type ClientContract } from '../../src';
+import { type ClientContract } from '../../src';
 import { schema } from '../schemas/basic';
+import { createTestClient } from '../utils';
 
-describe('Entity mutation hooks tests', () => {
-    let _client: ClientContract<typeof schema>;
+const TEST_DB = 'client-api-entity-mutation-hooks-test';
 
-    beforeEach(async () => {
-        _client = new ZenStackClient(schema, {
-            dialect: new SqliteDialect({ database: new SQLite(':memory:') }),
-        });
-        await _client.$pushSchema();
-    });
+describe.each([{ provider: 'sqlite' as const }, { provider: 'postgresql' as const }])(
+    'Entity mutation hooks tests for $provider',
+    ({ provider }) => {
+        let _client: ClientContract<typeof schema>;
 
-    afterEach(async () => {
-        await _client?.$disconnect();
-    });
-
-    it('can intercept all mutations', async () => {
-        const beforeCalled = { create: false, update: false, delete: false };
-        const afterCalled = { create: false, update: false, delete: false };
-
-        const client = _client.$use({
-            id: 'test',
-            onEntityMutation: {
-                beforeEntityMutation(args) {
-                    beforeCalled[args.action] = true;
-                    if (args.action === 'create') {
-                        expect(InsertQueryNode.is(args.queryNode)).toBe(true);
-                    }
-                    if (args.action === 'update') {
-                        expect(UpdateQueryNode.is(args.queryNode)).toBe(true);
-                    }
-                    if (args.action === 'delete') {
-                        expect(DeleteQueryNode.is(args.queryNode)).toBe(true);
-                    }
-                    expect(args.entities).toBeUndefined();
-                },
-                afterEntityMutation(args) {
-                    afterCalled[args.action] = true;
-                    expect(args.beforeMutationEntities).toBeUndefined();
-                    expect(args.afterMutationEntities).toBeUndefined();
-                },
-            },
+        beforeEach(async () => {
+            _client = await createTestClient(schema, {
+                provider,
+                dbName: TEST_DB,
+            });
         });
 
-        const user = await client.user.create({
-            data: { email: 'u1@test.com' },
-        });
-        await client.user.update({
-            where: { id: user.id },
-            data: { email: 'u2@test.com' },
-        });
-        await client.user.delete({ where: { id: user.id } });
-
-        expect(beforeCalled).toEqual({
-            create: true,
-            update: true,
-            delete: true,
-        });
-        expect(afterCalled).toEqual({
-            create: true,
-            update: true,
-            delete: true,
-        });
-    });
-
-    it('can intercept with filtering', async () => {
-        const beforeCalled = { create: false, update: false, delete: false };
-        const afterCalled = { create: false, update: false, delete: false };
-
-        const client = _client.$use({
-            id: 'test',
-            onEntityMutation: {
-                mutationInterceptionFilter: (args) => {
-                    return {
-                        intercept: args.action !== 'delete',
-                    };
-                },
-                beforeEntityMutation(args) {
-                    beforeCalled[args.action] = true;
-                    expect(args.entities).toBeUndefined();
-                },
-                afterEntityMutation(args) {
-                    afterCalled[args.action] = true;
-                },
-            },
+        afterEach(async () => {
+            await _client?.$disconnect();
         });
 
-        const user = await client.user.create({
-            data: { email: 'u1@test.com' },
-        });
-        await client.user.update({
-            where: { id: user.id },
-            data: { email: 'u2@test.com' },
-        });
-        await client.user.delete({ where: { id: user.id } });
+        it('can intercept all mutations', async () => {
+            const beforeCalled = { create: false, update: false, delete: false };
+            const afterCalled = { create: false, update: false, delete: false };
 
-        expect(beforeCalled).toEqual({
-            create: true,
-            update: true,
-            delete: false,
-        });
-        expect(afterCalled).toEqual({
-            create: true,
-            update: true,
-            delete: false,
-        });
-    });
-
-    it('can intercept with loading before mutation entities', async () => {
-        const client = _client.$use({
-            id: 'test',
-            onEntityMutation: {
-                mutationInterceptionFilter: () => {
-                    return {
-                        intercept: true,
-                        loadBeforeMutationEntities: true,
-                    };
-                },
-                beforeEntityMutation(args) {
-                    if (args.action === 'update' || args.action === 'delete') {
-                        expect(args.entities).toEqual([
-                            expect.objectContaining({
-                                email: args.action === 'update' ? 'u1@test.com' : 'u3@test.com',
-                            }),
-                        ]);
-                    } else {
-                        expect(args.entities).toBeUndefined();
-                    }
-                },
-                afterEntityMutation(args) {
-                    if (args.action === 'update' || args.action === 'delete') {
-                        expect(args.beforeMutationEntities).toEqual([
-                            expect.objectContaining({
-                                email: args.action === 'update' ? 'u1@test.com' : 'u3@test.com',
-                            }),
-                        ]);
-                    }
-                    expect(args.afterMutationEntities).toBeUndefined();
-                },
-            },
-        });
-
-        const user = await client.user.create({
-            data: { email: 'u1@test.com' },
-        });
-        await client.user.create({
-            data: { email: 'u2@test.com' },
-        });
-        await client.user.update({
-            where: { id: user.id },
-            data: { email: 'u3@test.com' },
-        });
-        await client.user.delete({ where: { id: user.id } });
-    });
-
-    it('can intercept with loading after mutation entities', async () => {
-        let userCreateIntercepted = false;
-        let userUpdateIntercepted = false;
-        const client = _client.$use({
-            id: 'test',
-            onEntityMutation: {
-                mutationInterceptionFilter: () => {
-                    return {
-                        intercept: true,
-                        loadAfterMutationEntities: true,
-                    };
-                },
-                afterEntityMutation(args) {
-                    if (args.action === 'create' || args.action === 'update') {
+            const client = _client.$use({
+                id: 'test',
+                onEntityMutation: {
+                    beforeEntityMutation(args) {
+                        beforeCalled[args.action] = true;
                         if (args.action === 'create') {
-                            userCreateIntercepted = true;
+                            expect(InsertQueryNode.is(args.queryNode)).toBe(true);
                         }
                         if (args.action === 'update') {
-                            userUpdateIntercepted = true;
+                            expect(UpdateQueryNode.is(args.queryNode)).toBe(true);
                         }
-                        expect(args.afterMutationEntities).toEqual(
-                            expect.arrayContaining([
-                                expect.objectContaining({
-                                    email: args.action === 'create' ? 'u1@test.com' : 'u2@test.com',
-                                }),
-                            ]),
-                        );
-                    } else {
+                        if (args.action === 'delete') {
+                            expect(DeleteQueryNode.is(args.queryNode)).toBe(true);
+                        }
+                        expect(args.entities).toBeUndefined();
+                    },
+                    afterEntityMutation(args) {
+                        afterCalled[args.action] = true;
+                        expect(args.beforeMutationEntities).toBeUndefined();
                         expect(args.afterMutationEntities).toBeUndefined();
-                    }
+                    },
                 },
-            },
+            });
+
+            const user = await client.user.create({
+                data: { email: 'u1@test.com' },
+            });
+            await client.user.update({
+                where: { id: user.id },
+                data: { email: 'u2@test.com' },
+            });
+            await client.user.delete({ where: { id: user.id } });
+
+            expect(beforeCalled).toEqual({
+                create: true,
+                update: true,
+                delete: true,
+            });
+            expect(afterCalled).toEqual({
+                create: true,
+                update: true,
+                delete: true,
+            });
         });
 
-        const user = await client.user.create({
-            data: { email: 'u1@test.com' },
-        });
-        await client.user.update({
-            where: { id: user.id },
-            data: { email: 'u2@test.com' },
-        });
+        it('can intercept with filtering', async () => {
+            const beforeCalled = { create: false, update: false, delete: false };
+            const afterCalled = { create: false, update: false, delete: false };
 
-        expect(userCreateIntercepted).toBe(true);
-        expect(userUpdateIntercepted).toBe(true);
-    });
-
-    it('can intercept multi-entity mutations', async () => {
-        let userCreateIntercepted = false;
-        let userUpdateIntercepted = false;
-        let userDeleteIntercepted = false;
-
-        const client = _client.$use({
-            id: 'test',
-            onEntityMutation: {
-                mutationInterceptionFilter: () => {
-                    return {
-                        intercept: true,
-                        loadAfterMutationEntities: true,
-                    };
+            const client = _client.$use({
+                id: 'test',
+                onEntityMutation: {
+                    mutationInterceptionFilter: (args) => {
+                        return {
+                            intercept: args.action !== 'delete',
+                        };
+                    },
+                    beforeEntityMutation(args) {
+                        beforeCalled[args.action] = true;
+                        expect(args.entities).toBeUndefined();
+                    },
+                    afterEntityMutation(args) {
+                        afterCalled[args.action] = true;
+                    },
                 },
-                afterEntityMutation(args) {
-                    if (args.action === 'create') {
-                        userCreateIntercepted = true;
-                        expect(args.afterMutationEntities).toEqual(
-                            expect.arrayContaining([
-                                expect.objectContaining({ email: 'u1@test.com' }),
-                                expect.objectContaining({ email: 'u2@test.com' }),
-                            ]),
-                        );
-                    } else if (args.action === 'update') {
-                        userUpdateIntercepted = true;
-                        expect(args.afterMutationEntities).toEqual(
-                            expect.arrayContaining([
+            });
+
+            const user = await client.user.create({
+                data: { email: 'u1@test.com' },
+            });
+            await client.user.update({
+                where: { id: user.id },
+                data: { email: 'u2@test.com' },
+            });
+            await client.user.delete({ where: { id: user.id } });
+
+            expect(beforeCalled).toEqual({
+                create: true,
+                update: true,
+                delete: false,
+            });
+            expect(afterCalled).toEqual({
+                create: true,
+                update: true,
+                delete: false,
+            });
+        });
+
+        it('can intercept with loading before mutation entities', async () => {
+            const client = _client.$use({
+                id: 'test',
+                onEntityMutation: {
+                    mutationInterceptionFilter: () => {
+                        return {
+                            intercept: true,
+                            loadBeforeMutationEntities: true,
+                        };
+                    },
+                    beforeEntityMutation(args) {
+                        if (args.action === 'update' || args.action === 'delete') {
+                            expect(args.entities).toEqual([
                                 expect.objectContaining({
-                                    email: 'u1@test.com',
-                                    name: 'A user',
+                                    email: args.action === 'update' ? 'u1@test.com' : 'u3@test.com',
                                 }),
+                            ]);
+                        } else {
+                            expect(args.entities).toBeUndefined();
+                        }
+                    },
+                    afterEntityMutation(args) {
+                        if (args.action === 'update' || args.action === 'delete') {
+                            expect(args.beforeMutationEntities).toEqual([
                                 expect.objectContaining({
-                                    email: 'u2@test.com',
-                                    name: 'A user',
+                                    email: args.action === 'update' ? 'u1@test.com' : 'u3@test.com',
                                 }),
-                            ]),
-                        );
-                    } else if (args.action === 'delete') {
-                        userDeleteIntercepted = true;
-                        expect(args.afterMutationEntities).toEqual(
-                            expect.arrayContaining([
-                                expect.objectContaining({ email: 'u1@test.com' }),
-                                expect.objectContaining({ email: 'u2@test.com' }),
-                            ]),
-                        );
-                    }
+                            ]);
+                        }
+                        expect(args.afterMutationEntities).toBeUndefined();
+                    },
                 },
-            },
+            });
+
+            const user = await client.user.create({
+                data: { email: 'u1@test.com' },
+            });
+            await client.user.create({
+                data: { email: 'u2@test.com' },
+            });
+            await client.user.update({
+                where: { id: user.id },
+                data: { email: 'u3@test.com' },
+            });
+            await client.user.delete({ where: { id: user.id } });
         });
 
-        await client.user.createMany({
-            data: [{ email: 'u1@test.com' }, { email: 'u2@test.com' }],
-        });
-        await client.user.updateMany({
-            data: { name: 'A user' },
-        });
-
-        expect(userCreateIntercepted).toBe(true);
-        expect(userUpdateIntercepted).toBe(true);
-        expect(userDeleteIntercepted).toBe(false);
-    });
-
-    it('can intercept nested mutations', async () => {
-        let post1Intercepted = false;
-        let post2Intercepted = false;
-        const client = _client.$use({
-            id: 'test',
-            onEntityMutation: {
-                mutationInterceptionFilter: (args) => {
-                    return {
-                        intercept: args.action === 'create' || args.action === 'update',
-                        loadAfterMutationEntities: true,
-                    };
-                },
-                afterEntityMutation(args) {
-                    if (args.action === 'create') {
-                        if (args.model === 'Post') {
-                            if ((args.afterMutationEntities![0] as any).title === 'Post1') {
-                                post1Intercepted = true;
+        it('can intercept with loading after mutation entities', async () => {
+            let userCreateIntercepted = false;
+            let userUpdateIntercepted = false;
+            const client = _client.$use({
+                id: 'test',
+                onEntityMutation: {
+                    mutationInterceptionFilter: () => {
+                        return {
+                            intercept: true,
+                            loadAfterMutationEntities: true,
+                        };
+                    },
+                    afterEntityMutation(args) {
+                        if (args.action === 'create' || args.action === 'update') {
+                            if (args.action === 'create') {
+                                userCreateIntercepted = true;
                             }
-                            if ((args.afterMutationEntities![0] as any).title === 'Post2') {
-                                post2Intercepted = true;
+                            if (args.action === 'update') {
+                                userUpdateIntercepted = true;
+                            }
+                            expect(args.afterMutationEntities).toEqual(
+                                expect.arrayContaining([
+                                    expect.objectContaining({
+                                        email: args.action === 'create' ? 'u1@test.com' : 'u2@test.com',
+                                    }),
+                                ]),
+                            );
+                        } else {
+                            expect(args.afterMutationEntities).toBeUndefined();
+                        }
+                    },
+                },
+            });
+
+            const user = await client.user.create({
+                data: { email: 'u1@test.com' },
+            });
+            await client.user.update({
+                where: { id: user.id },
+                data: { email: 'u2@test.com' },
+            });
+
+            expect(userCreateIntercepted).toBe(true);
+            expect(userUpdateIntercepted).toBe(true);
+        });
+
+        it('can intercept multi-entity mutations', async () => {
+            let userCreateIntercepted = false;
+            let userUpdateIntercepted = false;
+            let userDeleteIntercepted = false;
+
+            const client = _client.$use({
+                id: 'test',
+                onEntityMutation: {
+                    mutationInterceptionFilter: () => {
+                        return {
+                            intercept: true,
+                            loadAfterMutationEntities: true,
+                        };
+                    },
+                    afterEntityMutation(args) {
+                        if (args.action === 'create') {
+                            userCreateIntercepted = true;
+                            expect(args.afterMutationEntities).toEqual(
+                                expect.arrayContaining([
+                                    expect.objectContaining({ email: 'u1@test.com' }),
+                                    expect.objectContaining({ email: 'u2@test.com' }),
+                                ]),
+                            );
+                        } else if (args.action === 'update') {
+                            userUpdateIntercepted = true;
+                            expect(args.afterMutationEntities).toEqual(
+                                expect.arrayContaining([
+                                    expect.objectContaining({
+                                        email: 'u1@test.com',
+                                        name: 'A user',
+                                    }),
+                                    expect.objectContaining({
+                                        email: 'u2@test.com',
+                                        name: 'A user',
+                                    }),
+                                ]),
+                            );
+                        } else if (args.action === 'delete') {
+                            userDeleteIntercepted = true;
+                            expect(args.afterMutationEntities).toEqual(
+                                expect.arrayContaining([
+                                    expect.objectContaining({ email: 'u1@test.com' }),
+                                    expect.objectContaining({ email: 'u2@test.com' }),
+                                ]),
+                            );
+                        }
+                    },
+                },
+            });
+
+            await client.user.createMany({
+                data: [{ email: 'u1@test.com' }, { email: 'u2@test.com' }],
+            });
+            await client.user.updateMany({
+                data: { name: 'A user' },
+            });
+
+            expect(userCreateIntercepted).toBe(true);
+            expect(userUpdateIntercepted).toBe(true);
+            expect(userDeleteIntercepted).toBe(false);
+        });
+
+        it('can intercept nested mutations', async () => {
+            let post1Intercepted = false;
+            let post2Intercepted = false;
+            const client = _client.$use({
+                id: 'test',
+                onEntityMutation: {
+                    mutationInterceptionFilter: (args) => {
+                        return {
+                            intercept: args.action === 'create' || args.action === 'update',
+                            loadAfterMutationEntities: true,
+                        };
+                    },
+                    afterEntityMutation(args) {
+                        if (args.action === 'create') {
+                            if (args.model === 'Post') {
+                                if ((args.afterMutationEntities![0] as any).title === 'Post1') {
+                                    post1Intercepted = true;
+                                }
+                                if ((args.afterMutationEntities![0] as any).title === 'Post2') {
+                                    post2Intercepted = true;
+                                }
                             }
                         }
-                    }
+                    },
                 },
-            },
-        });
+            });
 
-        const user = await client.user.create({
-            data: {
-                email: 'u1@test.com',
-                posts: { create: { title: 'Post1' } },
-            },
-        });
-        await client.user.update({
-            where: { id: user.id },
-            data: {
-                email: 'u2@test.com',
-                posts: { create: { title: 'Post2' } },
-            },
-        });
-
-        expect(post1Intercepted).toBe(true);
-        expect(post2Intercepted).toBe(true);
-    });
-
-    it('does not affect the database operation if an afterEntityMutation hook throws', async () => {
-        let intercepted = false;
-
-        const client = _client.$use({
-            id: 'test',
-            onEntityMutation: {
-                afterEntityMutation() {
-                    intercepted = true;
-                    throw new Error('trigger rollback');
+            const user = await client.user.create({
+                data: {
+                    email: 'u1@test.com',
+                    posts: { create: { title: 'Post1' } },
                 },
-            },
-        });
-
-        await client.user.create({
-            data: { email: 'u1@test.com' },
-        });
-
-        expect(intercepted).toBe(true);
-        await expect(client.user.findMany()).toResolveWithLength(1);
-    });
-
-    it('does not trigger afterEntityMutation hook if a transaction is rolled back', async () => {
-        let intercepted = false;
-
-        const client = _client.$use({
-            id: 'test',
-            onEntityMutation: {
-                afterEntityMutation() {
-                    intercepted = true;
+            });
+            await client.user.update({
+                where: { id: user.id },
+                data: {
+                    email: 'u2@test.com',
+                    posts: { create: { title: 'Post2' } },
                 },
-            },
+            });
+
+            expect(post1Intercepted).toBe(true);
+            expect(post2Intercepted).toBe(true);
         });
 
-        try {
+        it('triggers multiple afterEntityMutation hooks for multiple mutations', async () => {
+            const triggered: any[] = [];
+
+            const client = _client.$use({
+                id: 'test',
+                onEntityMutation: {
+                    mutationInterceptionFilter: () => {
+                        return {
+                            intercept: true,
+                            loadBeforeMutationEntities: true,
+                            loadAfterMutationEntities: true,
+                        };
+                    },
+                    afterEntityMutation(args) {
+                        triggered.push(args);
+                    },
+                },
+            });
+
             await client.$transaction(async (tx) => {
                 await tx.user.create({
                     data: { email: 'u1@test.com' },
                 });
-                throw new Error('trigger rollback');
+                await tx.user.update({
+                    where: { email: 'u1@test.com' },
+                    data: { email: 'u2@test.com' },
+                });
+                await tx.user.delete({ where: { email: 'u2@test.com' } });
             });
-        } catch {
-            // noop
-        }
 
-        await expect(client.user.findMany()).toResolveWithLength(0);
-        expect(intercepted).toBe(false);
-    });
-
-    it('triggers multiple afterEntityMutation hooks for multiple mutations', async () => {
-        const triggered: any[] = [];
-
-        const client = _client.$use({
-            id: 'test',
-            onEntityMutation: {
-                mutationInterceptionFilter: () => {
-                    return {
-                        intercept: true,
-                        loadBeforeMutationEntities: true,
-                        loadAfterMutationEntities: true,
-                    };
-                },
-                afterEntityMutation(args) {
-                    triggered.push(args);
-                },
-            },
+            expect(triggered).toEqual([
+                expect.objectContaining({
+                    action: 'create',
+                    model: 'User',
+                    beforeMutationEntities: undefined,
+                    afterMutationEntities: [expect.objectContaining({ email: 'u1@test.com' })],
+                }),
+                expect.objectContaining({
+                    action: 'update',
+                    model: 'User',
+                    beforeMutationEntities: [expect.objectContaining({ email: 'u1@test.com' })],
+                    afterMutationEntities: [expect.objectContaining({ email: 'u2@test.com' })],
+                }),
+                expect.objectContaining({
+                    action: 'delete',
+                    model: 'User',
+                    beforeMutationEntities: [expect.objectContaining({ email: 'u2@test.com' })],
+                    afterMutationEntities: undefined,
+                }),
+            ]);
         });
 
-        await client.$transaction(async (tx) => {
-            await tx.user.create({
-                data: { email: 'u1@test.com' },
+        describe('Without outer transaction', () => {
+            it('persists hooks db side effects when run out of tx', async () => {
+                let intercepted = false;
+
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        async beforeEntityMutation(ctx) {
+                            await ctx.client.profile.create({
+                                data: { bio: 'Bio1' },
+                            });
+                        },
+                        async afterEntityMutation(ctx) {
+                            intercepted = true;
+                            await ctx.client.user.update({
+                                where: { email: 'u1@test.com' },
+                                data: { email: 'u2@test.com' },
+                            });
+                        },
+                    },
+                });
+
+                await client.user.create({
+                    data: { email: 'u1@test.com' },
+                });
+                expect(intercepted).toBe(true);
+                // both the mutation and hook's side effect are persisted
+                await expect(client.profile.findMany()).toResolveWithLength(1);
+                await expect(client.user.findFirst()).resolves.toMatchObject({ email: 'u2@test.com' });
             });
-            await tx.user.update({
-                where: { email: 'u1@test.com' },
-                data: { email: 'u2@test.com' },
+
+            it('persists hooks db side effects when run within tx', async () => {
+                let intercepted = false;
+
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        mutationInterceptionFilter: () => {
+                            return {
+                                intercept: true,
+                                runAfterMutationWithinTransaction: true,
+                            };
+                        },
+                        async beforeEntityMutation(ctx) {
+                            await ctx.client.profile.create({
+                                data: { bio: 'Bio1' },
+                            });
+                        },
+                        async afterEntityMutation(ctx) {
+                            intercepted = true;
+                            await ctx.client.user.update({
+                                where: { email: 'u1@test.com' },
+                                data: { email: 'u2@test.com' },
+                            });
+                        },
+                    },
+                });
+
+                await client.user.create({
+                    data: { email: 'u1@test.com' },
+                });
+                expect(intercepted).toBe(true);
+                // both the mutation and hook's side effect are persisted
+                await expect(client.profile.findMany()).toResolveWithLength(1);
+                await expect(client.user.findFirst()).resolves.toMatchObject({ email: 'u2@test.com' });
             });
-            await tx.user.delete({ where: { email: 'u2@test.com' } });
+
+            it('fails the mutation if before mutation hook throws', async () => {
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        async beforeEntityMutation() {
+                            throw new Error('trigger failure');
+                        },
+                    },
+                });
+
+                await expect(
+                    client.user.create({
+                        data: { email: 'u1@test.com' },
+                    }),
+                ).rejects.toThrow();
+
+                // mutation is persisted
+                await expect(client.user.findMany()).toResolveWithLength(0);
+            });
+
+            it('does not affect the database operation if after mutation hook throws', async () => {
+                let intercepted = false;
+
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        async afterEntityMutation() {
+                            intercepted = true;
+                            throw new Error('trigger rollback');
+                        },
+                    },
+                });
+
+                await client.user.create({
+                    data: { email: 'u1@test.com' },
+                });
+
+                expect(intercepted).toBe(true);
+                // mutation is persisted
+                await expect(client.user.findMany()).toResolveWithLength(1);
+            });
+
+            it('fails the entire transaction if specified to run inside the tx', async () => {
+                let intercepted = false;
+
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        mutationInterceptionFilter: () => {
+                            return {
+                                intercept: true,
+                                runAfterMutationWithinTransaction: true,
+                            };
+                        },
+                        async afterEntityMutation(ctx) {
+                            intercepted = true;
+                            await ctx.client.user.create({ data: { email: 'u2@test.com' } });
+                            throw new Error('trigger rollback');
+                        },
+                    },
+                });
+
+                await expect(
+                    client.user.create({
+                        data: { email: 'u1@test.com' },
+                    }),
+                ).rejects.toThrow();
+
+                expect(intercepted).toBe(true);
+                // mutation is not persisted
+                await expect(client.user.findMany()).toResolveWithLength(0);
+            });
+
+            it('does not trigger afterEntityMutation hook if a transaction is rolled back', async () => {
+                let intercepted = false;
+
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        async afterEntityMutation(ctx) {
+                            intercepted = true;
+                            await ctx.client.user.create({ data: { email: 'u2@test.com' } });
+                        },
+                    },
+                });
+
+                try {
+                    await client.$transaction(async (tx) => {
+                        await tx.user.create({
+                            data: { email: 'u1@test.com' },
+                        });
+                        throw new Error('trigger rollback');
+                    });
+                } catch {
+                    // noop
+                }
+
+                expect(intercepted).toBe(false);
+                // neither the mutation nor the hook's side effect are persisted
+                await expect(client.user.findMany()).toResolveWithLength(0);
+            });
+
+            it('triggers afterEntityMutation hook if a transaction is rolled back but hook runs within tx', async () => {
+                let intercepted = false;
+
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        mutationInterceptionFilter: () => {
+                            return {
+                                intercept: true,
+                                runAfterMutationWithinTransaction: true,
+                            };
+                        },
+                        async afterEntityMutation(ctx) {
+                            intercepted = true;
+                            await ctx.client.user.create({ data: { email: 'u2@test.com' } });
+                        },
+                    },
+                });
+
+                try {
+                    await client.$transaction(async (tx) => {
+                        await tx.user.create({
+                            data: { email: 'u1@test.com' },
+                        });
+                        throw new Error('trigger rollback');
+                    });
+                } catch {
+                    // noop
+                }
+
+                expect(intercepted).toBe(true);
+                // neither the mutation nor the hook's side effect are persisted
+                await expect(client.user.findMany()).toResolveWithLength(0);
+            });
         });
 
-        expect(triggered).toEqual([
-            expect.objectContaining({
-                action: 'create',
-                model: 'User',
-                beforeMutationEntities: undefined,
-                afterMutationEntities: [expect.objectContaining({ email: 'u1@test.com' })],
-            }),
-            expect.objectContaining({
-                action: 'update',
-                model: 'User',
-                beforeMutationEntities: [expect.objectContaining({ email: 'u1@test.com' })],
-                afterMutationEntities: [expect.objectContaining({ email: 'u2@test.com' })],
-            }),
-            expect.objectContaining({
-                action: 'delete',
-                model: 'User',
-                beforeMutationEntities: [expect.objectContaining({ email: 'u2@test.com' })],
-                afterMutationEntities: undefined,
-            }),
-        ]);
-    });
-});
+        describe('With outer transaction', () => {
+            it('sees changes in the transaction prior to reading before mutation entities', async () => {
+                let intercepted = false;
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        mutationInterceptionFilter: (ctx) => {
+                            return {
+                                intercept: ctx.action === 'update',
+                                loadBeforeMutationEntities: true,
+                            };
+                        },
+                        async beforeEntityMutation(ctx) {
+                            intercepted = true;
+                            expect(ctx.entities).toEqual([expect.objectContaining({ email: 'u1@test.com' })]);
+                        },
+                    },
+                });
+
+                await client.$transaction(async (tx) => {
+                    await tx.user.create({ data: { email: 'u1@test.com' } });
+                    await tx.user.update({
+                        where: { email: 'u1@test.com' },
+                        data: { email: 'u2@test.com' },
+                    });
+                });
+
+                expect(intercepted).toBe(true);
+            });
+
+            it('runs before mutation hook within the transaction', async () => {
+                let intercepted = false;
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        async beforeEntityMutation(ctx) {
+                            intercepted = true;
+                            await ctx.client.profile.create({
+                                data: { bio: 'Bio1' },
+                            });
+                        },
+                    },
+                });
+
+                await expect(
+                    client.$transaction(async (tx) => {
+                        await tx.user.create({
+                            data: { email: 'u1@test.com' },
+                        });
+                        throw new Error('trigger rollback');
+                    }),
+                ).rejects.toThrow();
+
+                expect(intercepted).toBe(true);
+                await expect(client.user.findMany()).toResolveWithLength(0);
+                await expect(client.profile.findMany()).toResolveWithLength(0);
+            });
+
+            it('persists hooks db side effects when run out of tx', async () => {
+                let intercepted = false;
+                let txVisible = false;
+
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        async beforeEntityMutation(ctx) {
+                            const r = await ctx.client.user.findUnique({ where: { email: 'u1@test.com' } });
+                            if (r) {
+                                // second create
+                                txVisible = true;
+                            } else {
+                                // first create
+                                await ctx.client.profile.create({
+                                    data: { bio: 'Bio1' },
+                                });
+                            }
+                        },
+                        async afterEntityMutation(ctx) {
+                            if (intercepted) {
+                                return;
+                            }
+                            intercepted = true;
+                            await ctx.client.user.update({
+                                where: { email: 'u1@test.com' },
+                                data: { email: 'u3@test.com' },
+                            });
+                        },
+                    },
+                });
+
+                await client.$transaction(async (tx) => {
+                    await tx.user.create({
+                        data: { email: 'u1@test.com' },
+                    });
+                    await tx.user.create({
+                        data: { email: 'u2@test.com' },
+                    });
+                });
+
+                expect(intercepted).toBe(true);
+                expect(txVisible).toBe(true);
+
+                // both the mutation and hook's side effect are persisted
+                await expect(client.profile.findMany()).toResolveWithLength(1);
+                await expect(client.user.findMany()).resolves.toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({ email: 'u2@test.com' }),
+                        expect.objectContaining({ email: 'u3@test.com' }),
+                    ]),
+                );
+            });
+
+            it('persists hooks db side effects when run within tx', async () => {
+                let intercepted = false;
+
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        mutationInterceptionFilter: () => {
+                            return {
+                                intercept: true,
+                                runAfterMutationWithinTransaction: true,
+                            };
+                        },
+                        async afterEntityMutation(ctx) {
+                            if (intercepted) {
+                                return;
+                            }
+                            intercepted = true;
+                            await ctx.client.user.update({
+                                where: { email: 'u1@test.com' },
+                                data: { email: 'u3@test.com' },
+                            });
+                        },
+                    },
+                });
+
+                await client.$transaction(async (tx) => {
+                    await tx.user.create({
+                        data: { email: 'u1@test.com' },
+                    });
+                    await tx.user.create({
+                        data: { email: 'u2@test.com' },
+                    });
+                });
+
+                expect(intercepted).toBe(true);
+
+                // both the mutation and hook's side effect are persisted
+                await expect(client.user.findMany()).resolves.toEqual(
+                    expect.arrayContaining([
+                        expect.objectContaining({ email: 'u2@test.com' }),
+                        expect.objectContaining({ email: 'u3@test.com' }),
+                    ]),
+                );
+            });
+
+            it('persists mutation when run out of tx and throws', async () => {
+                let intercepted = false;
+
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        async afterEntityMutation(ctx) {
+                            intercepted = true;
+                            await ctx.client.user.create({ data: { email: 'u2@test.com' } });
+                            throw new Error('trigger error');
+                        },
+                    },
+                });
+
+                await client.$transaction(async (tx) => {
+                    await tx.user.create({
+                        data: { email: 'u1@test.com' },
+                    });
+                });
+
+                expect(intercepted).toBe(true);
+
+                // both the mutation and hook's side effect are persisted
+                await expect(client.user.findMany()).toResolveWithLength(2);
+            });
+
+            it('rolls back mutation when run within tx and throws', async () => {
+                let intercepted = false;
+
+                const client = _client.$use({
+                    id: 'test',
+                    onEntityMutation: {
+                        mutationInterceptionFilter: () => {
+                            return {
+                                intercept: true,
+                                runAfterMutationWithinTransaction: true,
+                            };
+                        },
+                        async afterEntityMutation(ctx) {
+                            intercepted = true;
+                            await ctx.client.user.create({ data: { email: 'u2@test.com' } });
+                            throw new Error('trigger error');
+                        },
+                    },
+                });
+
+                await expect(
+                    client.$transaction(async (tx) => {
+                        await tx.user.create({
+                            data: { email: 'u1@test.com' },
+                        });
+                    }),
+                ).rejects.toThrow();
+
+                expect(intercepted).toBe(true);
+
+                // both the mutation and hook's side effect are rolled back
+                await expect(client.user.findMany()).toResolveWithLength(0);
+            });
+        });
+
+        it('triggers multiple afterEntityMutation hooks for multiple mutations', async () => {
+            const triggered: any[] = [];
+
+            const client = _client.$use({
+                id: 'test',
+                onEntityMutation: {
+                    mutationInterceptionFilter: () => {
+                        return {
+                            intercept: true,
+                            loadBeforeMutationEntities: true,
+                            loadAfterMutationEntities: true,
+                        };
+                    },
+                    afterEntityMutation(args) {
+                        triggered.push(args);
+                    },
+                },
+            });
+
+            await client.$transaction(async (tx) => {
+                await tx.user.create({
+                    data: { email: 'u1@test.com' },
+                });
+                await tx.user.update({
+                    where: { email: 'u1@test.com' },
+                    data: { email: 'u2@test.com' },
+                });
+                await tx.user.delete({ where: { email: 'u2@test.com' } });
+            });
+
+            expect(triggered).toEqual([
+                expect.objectContaining({
+                    action: 'create',
+                    model: 'User',
+                    beforeMutationEntities: undefined,
+                    afterMutationEntities: [expect.objectContaining({ email: 'u1@test.com' })],
+                }),
+                expect.objectContaining({
+                    action: 'update',
+                    model: 'User',
+                    beforeMutationEntities: [expect.objectContaining({ email: 'u1@test.com' })],
+                    afterMutationEntities: [expect.objectContaining({ email: 'u2@test.com' })],
+                }),
+                expect.objectContaining({
+                    action: 'delete',
+                    model: 'User',
+                    beforeMutationEntities: [expect.objectContaining({ email: 'u2@test.com' })],
+                    afterMutationEntities: undefined,
+                }),
+            ]);
+        });
+    },
+);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Plugin hooks now receive a client for in-transaction operations.
  - Optional run-after-mutation-within-transaction behavior for plugins.
  - Added a method to force running within a transaction.
- Bug Fixes
  - Commit callbacks failing no longer abort overall transaction commit.
- Refactor
  - Unified interceptor-driven query execution with improved alias/table handling and clearer errors.
- Tests
  - Expanded suite across SQLite and PostgreSQL, covering ORM and SQL-builder paths.
- Documentation
  - Terminology updates (Extensibility, plugin naming), ZModel additions, and filtering roadmap adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->