### PR TITLE
fix: potential field selection ambiguity

### DIFF
--- a/packages/runtime/src/client/crud/dialects/postgresql.ts
+++ b/packages/runtime/src/client/crud/dialects/postgresql.ts
@@ -266,7 +266,7 @@ export class PostgresCrudDialect<Schema extends SchemaDef> extends BaseCrudDiale
                                 ? // reference the synthesized JSON field
                                   eb.ref(`${parentResultName}$${field}.$data`)
                                 : // reference a plain field
-                                  this.fieldRef(relationModel, field, eb, undefined, false);
+                                  this.fieldRef(relationModel, field, eb, relationModelAlias, false);
                             return [sql.lit(field), fieldValue];
                         }
                     })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue in PostgreSQL queries where selecting scalar fields from related records could generate unqualified or ambiguous SQL. Fields are now correctly qualified with relation aliases, preventing errors and ensuring accurate results when using select on related models.
  * Improves reliability and consistency of query results without requiring any changes to existing usage.
* **Documentation**
  * No user-facing documentation changes.
* **Chores**
  * No API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->