### PR TITLE
chore: update vscode engine version

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Even without using advanced features, ZenStack offers the following benefits as 
 2. More TypeScript type inference, less code generation.
 3. Fully-typed query-builder API as a better escape hatch compared to Prisma's [raw queries](https://www.prisma.io/docs/orm/prisma-client/using-raw-sql/raw-queries) or [typed SQL](https://www.prisma.io/docs/orm/prisma-client/using-raw-sql/typedsql).
 
-> Although ZenStack v3's runtime doesn't depend on Prisma anymore (specifically, `@prisma/client`), it still relies on Prisma to handle database migration. See [database migration](<[#database-migration](https://zenstack.dev/docs/3.x/orm/migration)>) for more details.
+> Although ZenStack v3's runtime doesn't depend on Prisma anymore (specifically, `@prisma/client`), it still relies on Prisma to handle database migration. See [database migration](https://zenstack.dev/docs/3.x/orm/migration) for more details.
 
 # Quick start
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -41,7 +41,7 @@ function createProgram() {
         .description(
             `${colors.bold.blue(
                 'ζ',
-            )} ZenStack is the data layer for modern TypeScript apps.\n\nDocumentation: https://zenstack.dev.`,
+            )} ZenStack is the data layer for modern TypeScript apps.\n\nDocumentation: https://zenstack.dev/docs/3.x.`,
         )
         .showHelpAfterError()
         .showSuggestionAfterError();

--- a/packages/ide/vscode/package.json
+++ b/packages/ide/vscode/package.json
@@ -48,7 +48,7 @@
         "language-configuration.json"
     ],
     "engines": {
-        "vscode": "^1.63.0",
+        "vscode": "^1.90.0",
         "node": ">=20.0.0"
     },
     "categories": [

--- a/packages/ide/vscode/package.json
+++ b/packages/ide/vscode/package.json
@@ -36,7 +36,7 @@
         "vscode-languageserver": "^9.0.1"
     },
     "devDependencies": {
-        "@types/vscode": "^1.63.0",
+        "@types/vscode": "^1.90.0",
         "@zenstackhq/eslint-config": "workspace:*",
         "@zenstackhq/typescript-config": "workspace:*"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,7 +212,7 @@ importers:
         version: 9.0.1
     devDependencies:
       '@types/vscode':
-        specifier: ^1.63.0
+        specifier: ^1.90.0
         version: 1.101.0
       '@zenstackhq/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Updated VS Code compatibility requirement to v1.90.0 (supports >=1.90.0 <2.0.0). Users on older VS Code must upgrade; installs/updates will be blocked on earlier versions.
- Documentation
  - Fixed broken database migration link in the README so migration docs now point to the correct URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->