### PR TITLE
merge dev to main

### DIFF
--- a/packages/ide/vscode/package.json
+++ b/packages/ide/vscode/package.json
@@ -1,7 +1,7 @@
 {
     "name": "zenstack-v3",
     "publisher": "zenstack",
-    "version": "3.0.2",
+    "version": "3.0.5",
     "displayName": "ZenStack V3 Language Tools",
     "description": "VSCode extension for ZenStack (v3) ZModel language",
     "private": true,

--- a/packages/language/langium-config.json
+++ b/packages/language/langium-config.json
@@ -2,7 +2,7 @@
     "projectName": "ZModel",
     "languages": [
         {
-            "id": "zmodel",
+            "id": "zmodel-v3",
             "grammar": "src/zmodel.langium",
             "fileExtensions": [".zmodel"],
             "textMate": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the VS Code extension version to 3.0.5.

* **Refactor**
  * Updated the language identifier from “zmodel” to “zmodel-v3”.

Impact:
- Users will see the extension updated in VS Code with the new version.
- Workflows relying on the language identifier should switch to “zmodel-v3” (e.g., language settings, file associations, and tooling configurations).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->