### PR TITLE
fix: optimize findFirst

### DIFF
--- a/packages/runtime/src/client/crud/operations/find.ts
+++ b/packages/runtime/src/client/crud/operations/find.ts
@@ -8,15 +8,19 @@ export class FindOperationHandler<Schema extends SchemaDef> extends BaseOperatio
         const normalizedArgs = this.normalizeArgs(args);
 
         // parse args
-        const parsedArgs = validateArgs
+        const parsedArgs = (validateArgs
             ? this.inputValidator.validateFindArgs(this.model, operation === 'findUnique', normalizedArgs)
-            : normalizedArgs;
+            : normalizedArgs) as FindArgs<Schema, GetModels<Schema>, true>;
+
+        if (operation === 'findFirst') {
+            parsedArgs.take = 1;
+        }
 
         // run query
         const result = await this.read(
             this.client.$qb,
             this.model,
-            parsedArgs as FindArgs<Schema, GetModels<Schema>, true>,
+            parsedArgs,
         );
 
         const finalResult = operation === 'findMany' ? result : (result[0] ?? null);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Single-result queries now consistently return only one item (e.g., first-match lookups no longer over-fetch); multi-result queries unchanged.

* **Refactor**
  * Internal handling of query arguments streamlined to improve reliability and reduce edge cases, with no changes to public behavior or interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->