### PR TITLE
fix: findFirst args validation issues

### DIFF
--- a/packages/runtime/test/client-api/computed-fields.test.ts
+++ b/packages/runtime/test/client-api/computed-fields.test.ts
@@ -75,7 +75,7 @@ model User {
             await expect(
                 db.user.findFirst({
                     orderBy: { upperName: 'desc' },
-                    take: -1,
+                    take: 1,
                 }),
             ).resolves.toMatchObject({
                 upperName: 'ALEX',

--- a/packages/runtime/test/client-api/find.test.ts
+++ b/packages/runtime/test/client-api/find.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { ClientContract } from '../../src/client';
-import { NotFoundError } from '../../src/client/errors';
+import { InputValidationError, NotFoundError } from '../../src/client/errors';
 import { schema } from '../schemas/basic';
 import { createClientSpecs } from './client-specs';
 import { createPosts, createUser } from './utils';
@@ -53,6 +53,10 @@ describe.each(createClientSpecs(PG_DB_NAME))('Client find tests for $provider', 
         await expect(client.user.findMany({ take: 1 })).resolves.toHaveLength(1);
         await expect(client.user.findMany({ take: 2 })).resolves.toHaveLength(2);
         await expect(client.user.findMany({ take: 4 })).resolves.toHaveLength(3);
+
+        // findFirst's take must be 1
+        await expect(client.user.findFirst({ take: 2 })).rejects.toThrow(InputValidationError);
+        await expect(client.user.findFirst({ take: 1 })).toResolveTruthy();
 
         // skip
         await expect(client.user.findMany({ skip: 1 })).resolves.toHaveLength(2);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - findFirst and findUnique now consistently return a single record; requests are constrained to take = 1 where applicable.
  - Invalid take values for single-record queries now produce a clear InputValidationError.

- Bug Fixes
  - Improved consistency when ordering by computed fields during first-record retrieval.

- Tests
  - Expanded coverage for single-record query validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->