### PR TITLE
feat: "create" access policy implementation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -86,6 +86,7 @@
         - [ ] Global omit
         - [ ] DbNull vs JsonNull
         - [ ] Migrate to tsdown
+        - [ ] @default validation
     - [ ] Benchmark
 - [x] Plugin
     - [x] Post-mutation hooks should be called after transaction is committed

--- a/TODO.md
+++ b/TODO.md
@@ -83,6 +83,7 @@
         - [x] Error system
         - [x] Custom table name
         - [x] Custom field name
+        - [ ] Global omit
         - [ ] DbNull vs JsonNull
         - [ ] Migrate to tsdown
     - [ ] Benchmark

--- a/packages/language/src/validators/attribute-application-validator.ts
+++ b/packages/language/src/validators/attribute-application-validator.ts
@@ -154,24 +154,6 @@ export default class AttributeApplicationValidator implements AstValidator<Attri
         }
     }
 
-    @check('@default')
-    // @ts-expect-error
-    private _checkDefault(attr: AttributeApplication, accept: ValidationAcceptor) {
-        if (attr.$container && isDataField(attr.$container) && attr.$container.type.type === 'Json') {
-            // Json field default value must be a valid JSON string
-            const value = getStringLiteral(attr.args[0]?.value);
-            if (!value) {
-                accept('error', 'value must be a valid JSON string', { node: attr });
-                return;
-            }
-            try {
-                JSON.parse(value);
-            } catch {
-                accept('error', 'value is not a valid JSON string', { node: attr });
-            }
-        }
-    }
-
     // TODO: design a way to let plugin register validation
     @check('@@allow')
     @check('@@deny')

--- a/packages/runtime/src/client/crud/operations/base.ts
+++ b/packages/runtime/src/client/crud/operations/base.ts
@@ -860,9 +860,13 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
                     values[field] = this.dialect.transformPrimitive(new Date(), 'DateTime', false);
                 } else if (fields[field]?.default !== undefined) {
                     let value = fields[field].default;
-                    if (fieldDef.type === 'Json' && typeof value === 'string') {
+                    if (fieldDef.type === 'Json') {
                         // Schema uses JSON string for default value of Json fields
-                        value = JSON.parse(value);
+                        if (fieldDef.array && Array.isArray(value)) {
+                            value = value.map((v) => (typeof v === 'string' ? JSON.parse(v) : v));
+                        } else if (typeof value === 'string') {
+                            value = JSON.parse(value);
+                        }
                     }
                     values[field] = this.dialect.transformPrimitive(
                         value,

--- a/packages/runtime/src/client/crud/validator.ts
+++ b/packages/runtime/src/client/crud/validator.ts
@@ -22,12 +22,11 @@ import {
     type UpdateManyArgs,
     type UpsertArgs,
 } from '../crud-types';
-import { InputValidationError, InternalError, QueryError } from '../errors';
+import { InputValidationError, InternalError } from '../errors';
 import {
     fieldHasDefaultValue,
     getDiscriminatorField,
     getEnum,
-    getModel,
     getUniqueFields,
     requireField,
     requireModel,
@@ -279,10 +278,7 @@ export class InputValidator<Schema extends SchemaDef> {
         withoutRelationFields = false,
         withAggregations = false,
     ): ZodType {
-        const modelDef = getModel(this.schema, model);
-        if (!modelDef) {
-            throw new QueryError(`Model "${model}" not found in schema`);
-        }
+        const modelDef = requireModel(this.schema, model);
 
         const fields: Record<string, any> = {};
         for (const field of Object.keys(modelDef.fields)) {

--- a/packages/runtime/src/client/executor/kysely-utils.ts
+++ b/packages/runtime/src/client/executor/kysely-utils.ts
@@ -1,13 +1,11 @@
-import { invariant } from '@zenstackhq/common-helpers';
-import { type OperationNode, AliasNode, IdentifierNode } from 'kysely';
+import { type OperationNode, AliasNode } from 'kysely';
 
 /**
  * Strips alias from the node if it exists.
  */
 export function stripAlias(node: OperationNode) {
     if (AliasNode.is(node)) {
-        invariant(IdentifierNode.is(node.alias), 'Expected identifier as alias');
-        return { alias: node.alias.name, node: node.node };
+        return { alias: node.alias, node: node.node };
     } else {
         return { alias: undefined, node };
     }

--- a/packages/runtime/src/client/executor/zenstack-query-executor.ts
+++ b/packages/runtime/src/client/executor/zenstack-query-executor.ts
@@ -100,7 +100,6 @@ export class ZenStackQueryExecutor<Schema extends SchemaDef> extends DefaultQuer
                 const hookResult = await hook!({
                     client: this.client as ClientContract<Schema>,
                     schema: this.client.$schema,
-                    kysely: this.kysely,
                     query,
                     proceed: _p,
                 });

--- a/packages/runtime/src/client/plugin.ts
+++ b/packages/runtime/src/client/plugin.ts
@@ -1,5 +1,5 @@
 import type { OperationNode, QueryResult, RootOperationNode, UnknownRow } from 'kysely';
-import type { ClientContract, ToKysely } from '.';
+import type { ClientContract } from '.';
 import type { GetModels, SchemaDef } from '../schema';
 import type { MaybePromise } from '../utils/type-utils';
 import type { AllCrudOperation } from './crud/operations/base';
@@ -180,7 +180,6 @@ export type PluginAfterEntityMutationArgs<Schema extends SchemaDef> = MutationHo
 // #region OnKyselyQuery hooks
 
 export type OnKyselyQueryArgs<Schema extends SchemaDef> = {
-    kysely: ToKysely<Schema>;
     schema: SchemaDef;
     client: ClientContract<Schema>;
     query: RootOperationNode;

--- a/packages/runtime/src/client/query-utils.ts
+++ b/packages/runtime/src/client/query-utils.ts
@@ -14,7 +14,7 @@ export function hasModel(schema: SchemaDef, model: string) {
 }
 
 export function getModel(schema: SchemaDef, model: string) {
-    return schema.models[model];
+    return Object.values(schema.models).find((m) => m.name.toLowerCase() === model.toLowerCase());
 }
 
 export function getTypeDef(schema: SchemaDef, type: string) {
@@ -22,11 +22,11 @@ export function getTypeDef(schema: SchemaDef, type: string) {
 }
 
 export function requireModel(schema: SchemaDef, model: string) {
-    const matchedName = Object.keys(schema.models).find((k) => k.toLowerCase() === model.toLowerCase());
-    if (!matchedName) {
+    const modelDef = getModel(schema, model);
+    if (!modelDef) {
         throw new QueryError(`Model "${model}" not found in schema`);
     }
-    return schema.models[matchedName]!;
+    return modelDef;
 }
 
 export function getField(schema: SchemaDef, model: string, field: string) {

--- a/packages/runtime/src/client/query-utils.ts
+++ b/packages/runtime/src/client/query-utils.ts
@@ -17,6 +17,10 @@ export function getModel(schema: SchemaDef, model: string) {
     return schema.models[model];
 }
 
+export function getTypeDef(schema: SchemaDef, type: string) {
+    return schema.typeDefs?.[type];
+}
+
 export function requireModel(schema: SchemaDef, model: string) {
     const matchedName = Object.keys(schema.models).find((k) => k.toLowerCase() === model.toLowerCase());
     if (!matchedName) {
@@ -30,12 +34,24 @@ export function getField(schema: SchemaDef, model: string, field: string) {
     return modelDef?.fields[field];
 }
 
-export function requireField(schema: SchemaDef, model: string, field: string) {
-    const modelDef = requireModel(schema, model);
-    if (!modelDef.fields[field]) {
-        throw new QueryError(`Field "${field}" not found in model "${model}"`);
+export function requireField(schema: SchemaDef, modelOrType: string, field: string) {
+    const modelDef = getModel(schema, modelOrType);
+    if (modelDef) {
+        if (!modelDef.fields[field]) {
+            throw new QueryError(`Field "${field}" not found in model "${modelOrType}"`);
+        } else {
+            return modelDef.fields[field];
+        }
     }
-    return modelDef.fields[field];
+    const typeDef = getTypeDef(schema, modelOrType);
+    if (typeDef) {
+        if (!typeDef.fields[field]) {
+            throw new QueryError(`Field "${field}" not found in type "${modelOrType}"`);
+        } else {
+            return typeDef.fields[field];
+        }
+    }
+    throw new QueryError(`Model or type "${modelOrType}" not found in schema`);
 }
 
 export function getIdFields<Schema extends SchemaDef>(schema: SchemaDef, model: GetModels<Schema>) {

--- a/packages/runtime/src/plugins/policy/expression-transformer.ts
+++ b/packages/runtime/src/plugins/policy/expression-transformer.ts
@@ -25,7 +25,7 @@ import { getCrudDialect } from '../../client/crud/dialects';
 import type { BaseCrudDialect } from '../../client/crud/dialects/base';
 import { InternalError, QueryError } from '../../client/errors';
 import type { ClientOptions } from '../../client/options';
-import { getRelationForeignKeyFieldPairs, requireField } from '../../client/query-utils';
+import { getModel, getRelationForeignKeyFieldPairs, requireField } from '../../client/query-utils';
 import type {
     BinaryExpression,
     BinaryOperator,
@@ -51,8 +51,6 @@ export type ExpressionTransformerContext<Schema extends SchemaDef> = {
     model: GetModels<Schema>;
     alias?: string;
     operation: CRUD;
-    thisEntity?: Record<string, OperationNode>;
-    thisEntityRaw?: Record<string, unknown>;
     auth?: any;
     memberFilter?: OperationNode;
     memberSelect?: SelectionNode;
@@ -86,7 +84,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
         if (!this.schema.authType) {
             throw new InternalError('Schema does not have an "authType" specified');
         }
-        return this.schema.authType;
+        return this.schema.authType!;
     }
 
     transform(expression: Expression, context: ExpressionTransformerContext<Schema>): OperationNode {
@@ -117,11 +115,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
     private _field(expr: FieldExpression, context: ExpressionTransformerContext<Schema>) {
         const fieldDef = requireField(this.schema, context.model, expr.field);
         if (!fieldDef.relation) {
-            if (context.thisEntity) {
-                return context.thisEntity[expr.field];
-            } else {
-                return this.createColumnRef(expr.field, context);
-            }
+            return this.createColumnRef(expr.field, context);
         } else {
             const { memberFilter, memberSelect, ...restContext } = context;
             const relation = this.transformRelationAccess(expr.field, fieldDef.type, restContext);
@@ -159,7 +153,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
         }
 
         if (this.isAuthCall(expr.left) || this.isAuthCall(expr.right)) {
-            return this.transformAuthBinary(expr);
+            return this.transformAuthBinary(expr, context);
         }
 
         const op = expr.op;
@@ -234,7 +228,6 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
             ...context,
             model: newContextModel as GetModels<Schema>,
             alias: undefined,
-            thisEntity: undefined,
         });
 
         if (expr.op === '!') {
@@ -256,21 +249,50 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
         });
     }
 
-    private transformAuthBinary(expr: BinaryExpression) {
+    private transformAuthBinary(expr: BinaryExpression, context: ExpressionTransformerContext<Schema>) {
         if (expr.op !== '==' && expr.op !== '!=') {
-            throw new Error(`Unsupported operator for auth call: ${expr.op}`);
+            throw new QueryError(
+                `Unsupported operator for \`auth()\` in policy of model "${context.model}": ${expr.op}`,
+            );
         }
+
+        let authExpr: Expression;
         let other: Expression;
         if (this.isAuthCall(expr.left)) {
+            authExpr = expr.left;
             other = expr.right;
         } else {
+            authExpr = expr.right;
             other = expr.left;
         }
 
         if (ExpressionUtils.isNull(other)) {
             return this.transformValue(expr.op === '==' ? !this.auth : !!this.auth, 'Boolean');
         } else {
-            throw new Error('Unsupported binary expression with `auth()`');
+            const authModel = getModel(this.schema, this.authType);
+            if (!authModel) {
+                throw new QueryError(
+                    `Unsupported use of \`auth()\` in policy of model "${this}", comparing with \`auth()\` is only possible when auth type is a model`,
+                );
+            }
+
+            const idFields = Object.values(authModel.fields)
+                .filter((f) => f.id)
+                .map((f) => f.name);
+            invariant(idFields.length > 0, 'auth type model must have at least one id field');
+
+            const conditions = idFields.map((fieldName) =>
+                ExpressionUtils.binary(
+                    ExpressionUtils.member(authExpr, [fieldName]),
+                    '==',
+                    ExpressionUtils.member(other, [fieldName]),
+                ),
+            );
+            let result = this.buildAnd(conditions);
+            if (expr.op === '!=') {
+                result = this.buildLogicalNot(result);
+            }
+            return this.transform(result, context);
         }
     }
 
@@ -331,7 +353,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
         }
 
         if (ExpressionUtils.isField(arg)) {
-            return context.thisEntityRaw ? eb.val(context.thisEntityRaw[arg.field]) : eb.ref(arg.field);
+            return eb.ref(arg.field);
         }
 
         if (ExpressionUtils.isCall(arg)) {
@@ -358,20 +380,46 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
             return this.valueMemberAccess(this.auth, expr, this.authType);
         }
 
-        invariant(ExpressionUtils.isField(expr.receiver), 'expect receiver to be field expression');
+        invariant(
+            ExpressionUtils.isField(expr.receiver) || ExpressionUtils.isThis(expr.receiver),
+            'expect receiver to be field expression or "this"',
+        );
 
+        let members = expr.members;
+        let receiver: OperationNode;
         const { memberFilter, memberSelect, ...restContext } = context;
 
-        const receiver = this.transform(expr.receiver, restContext);
+        if (ExpressionUtils.isThis(expr.receiver)) {
+            if (expr.members.length === 1) {
+                // optimize for the simple this.scalar case
+                const fieldDef = requireField(this.schema, context.model, expr.members[0]!);
+                invariant(!fieldDef.relation, 'this.relation access should have been transformed into relation access');
+                return this.createColumnRef(expr.members[0]!, restContext);
+            }
+
+            // transform the first segment into a relation access, then continue with the rest of the members
+            const firstMemberFieldDef = requireField(this.schema, context.model, expr.members[0]!);
+            receiver = this.transformRelationAccess(expr.members[0]!, firstMemberFieldDef.type, restContext);
+            members = expr.members.slice(1);
+        } else {
+            receiver = this.transform(expr.receiver, restContext);
+        }
+
         invariant(SelectQueryNode.is(receiver), 'expected receiver to be select query');
 
-        // relation member access
-        const receiverField = requireField(this.schema, context.model, expr.receiver.field);
+        let startType: string;
+        if (ExpressionUtils.isField(expr.receiver)) {
+            const receiverField = requireField(this.schema, context.model, expr.receiver.field);
+            startType = receiverField.type;
+        } else {
+            // "this." case, start type is the model of the context
+            startType = context.model;
+        }
 
         // traverse forward to collect member types
         const memberFields: { fromModel: string; fieldDef: FieldDef }[] = [];
-        let currType = receiverField.type;
-        for (const member of expr.members) {
+        let currType = startType;
+        for (const member of members) {
             const fieldDef = requireField(this.schema, currType, member);
             memberFields.push({ fieldDef, fromModel: currType });
             currType = fieldDef.type;
@@ -379,8 +427,8 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
 
         let currNode: SelectQueryNode | ColumnNode | ReferenceNode | undefined = undefined;
 
-        for (let i = expr.members.length - 1; i >= 0; i--) {
-            const member = expr.members[i]!;
+        for (let i = members.length - 1; i >= 0; i--) {
+            const member = members[i]!;
             const { fieldDef, fromModel } = memberFields[i]!;
 
             if (fieldDef.relation) {
@@ -388,7 +436,6 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                     ...restContext,
                     model: fromModel as GetModels<Schema>,
                     alias: undefined,
-                    thisEntity: undefined,
                 });
 
                 if (currNode) {
@@ -396,9 +443,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                     currNode = {
                         ...relation,
                         selections: [
-                            SelectionNode.create(
-                                AliasNode.create(currNode, IdentifierNode.create(expr.members[i + 1]!)),
-                            ),
+                            SelectionNode.create(AliasNode.create(currNode, IdentifierNode.create(members[i + 1]!))),
                         ],
                     };
                 } else {
@@ -410,7 +455,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
                     };
                 }
             } else {
-                invariant(i === expr.members.length - 1, 'plain field access must be the last segment');
+                invariant(i === members.length - 1, 'plain field access must be the last segment');
                 invariant(!currNode, 'plain field access must be the last segment');
 
                 currNode = ColumnNode.create(member);
@@ -446,71 +491,38 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
         const fromModel = context.model;
         const { keyPairs, ownedByModel } = getRelationForeignKeyFieldPairs(this.schema, fromModel, field);
 
-        if (context.thisEntity) {
-            let condition: OperationNode;
-            if (ownedByModel) {
-                condition = conjunction(
-                    this.dialect,
-                    keyPairs.map(({ fk, pk }) =>
-                        BinaryOperationNode.create(
-                            ReferenceNode.create(ColumnNode.create(pk), TableNode.create(relationModel)),
-                            OperatorNode.create('='),
-                            context.thisEntity![fk]!,
-                        ),
+        let condition: OperationNode;
+        if (ownedByModel) {
+            // `fromModel` owns the fk
+            condition = conjunction(
+                this.dialect,
+                keyPairs.map(({ fk, pk }) =>
+                    BinaryOperationNode.create(
+                        ReferenceNode.create(ColumnNode.create(fk), TableNode.create(context.alias ?? fromModel)),
+                        OperatorNode.create('='),
+                        ReferenceNode.create(ColumnNode.create(pk), TableNode.create(relationModel)),
                     ),
-                );
-            } else {
-                condition = conjunction(
-                    this.dialect,
-                    keyPairs.map(({ fk, pk }) =>
-                        BinaryOperationNode.create(
-                            ReferenceNode.create(ColumnNode.create(fk), TableNode.create(relationModel)),
-                            OperatorNode.create('='),
-                            context.thisEntity![pk]!,
-                        ),
-                    ),
-                );
-            }
-
-            return {
-                kind: 'SelectQueryNode',
-                from: FromNode.create([TableNode.create(relationModel)]),
-                where: WhereNode.create(condition),
-            };
+                ),
+            );
         } else {
-            let condition: OperationNode;
-            if (ownedByModel) {
-                // `fromModel` owns the fk
-                condition = conjunction(
-                    this.dialect,
-                    keyPairs.map(({ fk, pk }) =>
-                        BinaryOperationNode.create(
-                            ReferenceNode.create(ColumnNode.create(fk), TableNode.create(context.alias ?? fromModel)),
-                            OperatorNode.create('='),
-                            ReferenceNode.create(ColumnNode.create(pk), TableNode.create(relationModel)),
-                        ),
+            // `relationModel` owns the fk
+            condition = conjunction(
+                this.dialect,
+                keyPairs.map(({ fk, pk }) =>
+                    BinaryOperationNode.create(
+                        ReferenceNode.create(ColumnNode.create(pk), TableNode.create(context.alias ?? fromModel)),
+                        OperatorNode.create('='),
+                        ReferenceNode.create(ColumnNode.create(fk), TableNode.create(relationModel)),
                     ),
-                );
-            } else {
-                // `relationModel` owns the fk
-                condition = conjunction(
-                    this.dialect,
-                    keyPairs.map(({ fk, pk }) =>
-                        BinaryOperationNode.create(
-                            ReferenceNode.create(ColumnNode.create(pk), TableNode.create(context.alias ?? fromModel)),
-                            OperatorNode.create('='),
-                            ReferenceNode.create(ColumnNode.create(fk), TableNode.create(relationModel)),
-                        ),
-                    ),
-                );
-            }
-
-            return {
-                kind: 'SelectQueryNode',
-                from: FromNode.create([TableNode.create(relationModel)]),
-                where: WhereNode.create(condition),
-            };
+                ),
+            );
         }
+
+        return {
+            kind: 'SelectQueryNode',
+            from: FromNode.create([TableNode.create(relationModel)]),
+            where: WhereNode.create(condition),
+        };
     }
 
     private createColumnRef(column: string, context: ExpressionTransformerContext<Schema>): ReferenceNode {
@@ -527,5 +539,19 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
 
     private isNullNode(node: OperationNode) {
         return ValueNode.is(node) && node.value === null;
+    }
+
+    private buildLogicalNot(result: Expression): Expression {
+        return ExpressionUtils.unary('!', result);
+    }
+
+    private buildAnd(conditions: BinaryExpression[]): Expression {
+        if (conditions.length === 0) {
+            return ExpressionUtils.literal(true);
+        } else if (conditions.length === 1) {
+            return conditions[0]!;
+        } else {
+            return conditions.reduce((acc, condition) => ExpressionUtils.binary(acc, '&&', condition));
+        }
     }
 }

--- a/packages/runtime/src/plugins/policy/expression-transformer.ts
+++ b/packages/runtime/src/plugins/policy/expression-transformer.ts
@@ -272,7 +272,7 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
             const authModel = getModel(this.schema, this.authType);
             if (!authModel) {
                 throw new QueryError(
-                    `Unsupported use of \`auth()\` in policy of model "${this}", comparing with \`auth()\` is only possible when auth type is a model`,
+                    `Unsupported use of \`auth()\` in policy of model "${context.model}", comparing with \`auth()\` is only possible when auth type is a model`,
                 );
             }
 

--- a/packages/runtime/src/schema/expression.ts
+++ b/packages/runtime/src/schema/expression.ts
@@ -88,6 +88,10 @@ export const ExpressionUtils = {
         return expressions.reduce((acc, exp) => ExpressionUtils.binary(acc, '||', exp), expr);
     },
 
+    not: (expr: Expression) => {
+        return ExpressionUtils.unary('!', expr);
+    },
+
     is: (value: unknown, kind: Expression['kind']): value is Expression => {
         return !!value && typeof value === 'object' && 'kind' in value && value.kind === kind;
     },

--- a/packages/runtime/test/plugin/on-kysely-query.test.ts
+++ b/packages/runtime/test/plugin/on-kysely-query.test.ts
@@ -84,7 +84,7 @@ describe('On kysely query tests', () => {
     it('supports spawning multiple queries', async () => {
         const client = _client.$use({
             id: 'test-plugin',
-            async onKyselyQuery({ kysely, proceed, query }) {
+            async onKyselyQuery({ client, proceed, query }) {
                 if (query.kind !== 'InsertQueryNode') {
                     return proceed(query);
                 }
@@ -92,7 +92,7 @@ describe('On kysely query tests', () => {
                 const result = await proceed(query);
 
                 // create a post for the user
-                await proceed(createPost(kysely, result));
+                await proceed(createPost(client.$qb, result));
 
                 return result;
             },

--- a/packages/runtime/test/policy/crud/create.test.ts
+++ b/packages/runtime/test/policy/crud/create.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import { createPolicyTestClient } from '../utils';
+
+describe('Policy create tests', () => {
+    it('works with scalar field check', async () => {
+        const db = await createPolicyTestClient(
+            `
+model Foo {
+    id Int @id @default(autoincrement())
+    x  Int
+    @@allow('create', x > 0)
+    @@allow('read', true)
+}
+`,
+        );
+        await expect(db.foo.create({ data: { x: 0 } })).toBeRejectedByPolicy();
+        await expect(db.foo.create({ data: { x: 1 } })).resolves.toMatchObject({ x: 1 });
+    });
+
+    it('works with this scalar member check', async () => {
+        const db = await createPolicyTestClient(
+            `
+model Foo {
+    id Int @id @default(autoincrement())
+    x  Int
+    @@allow('create', this.x > 0)
+    @@allow('read', true)
+}
+`,
+        );
+        await expect(db.foo.create({ data: { x: 0 } })).toBeRejectedByPolicy();
+        await expect(db.foo.create({ data: { x: 1 } })).resolves.toMatchObject({ x: 1 });
+    });
+
+    it('denies by default', async () => {
+        const db = await createPolicyTestClient(
+            `
+model Foo {
+    id Int @id @default(autoincrement())
+    x  Int
+}
+`,
+        );
+        await expect(db.foo.create({ data: { x: 0 } })).toBeRejectedByPolicy();
+    });
+
+    it('works with deny rule', async () => {
+        const db = await createPolicyTestClient(
+            `
+model Foo {
+    id Int @id @default(autoincrement())
+    x  Int
+    @@deny('create', x <= 0)
+    @@allow('create,read', true)
+}
+`,
+        );
+        await expect(db.foo.create({ data: { x: 0 } })).toBeRejectedByPolicy();
+        await expect(db.foo.create({ data: { x: 1 } })).resolves.toMatchObject({ x: 1 });
+    });
+
+    it('works with mixed allow and deny rules', async () => {
+        const db = await createPolicyTestClient(
+            `
+model Foo {
+    id Int @id @default(autoincrement())
+    x  Int
+    @@deny('create', x <= 0)
+    @@allow('create', x > 1)
+    @@allow('read', true)
+}
+`,
+        );
+        await expect(db.foo.create({ data: { x: 0 } })).toBeRejectedByPolicy();
+        await expect(db.foo.create({ data: { x: 1 } })).toBeRejectedByPolicy();
+        await expect(db.foo.create({ data: { x: 2 } })).resolves.toMatchObject({ x: 2 });
+    });
+
+    it('works with non-provided fields', async () => {
+        const db = await createPolicyTestClient(
+            `
+model Foo {
+    id Int @id @default(autoincrement())
+    x  Int @default(0)
+    @@allow('create', x > 0)
+    @@allow('read', true)
+}
+`,
+        );
+        await expect(db.foo.create({ data: {} })).toBeRejectedByPolicy();
+        await expect(db.foo.create({ data: { x: 1 } })).toResolveTruthy();
+    });
+
+    it('works with db-generated fields', async () => {
+        const db = await createPolicyTestClient(
+            `
+model Foo {
+    id Int @id @default(autoincrement())
+    @@allow('create', id > 0)
+    @@allow('read', true)
+}
+`,
+        );
+        await expect(db.foo.create({ data: {} })).toBeRejectedByPolicy();
+        await expect(db.foo.create({ data: { id: 1 } })).toResolveTruthy();
+    });
+
+    it('rejects non-owned relation reference', async () => {
+        await expect(
+            createPolicyTestClient(
+                `
+model User {
+    id Int @id
+    profile Profile?
+    @@allow('create', profile == null)
+    @@allow('read', true)
+}
+
+model Profile {
+    id Int @id
+    name String
+    user User @relation(fields: [userId], references: [id])
+    userId Int @unique
+}
+            `,
+            ),
+        ).rejects.toThrow('non-owned relation fields are not allowed in "create" rules');
+    });
+
+    it('works with auth check', async () => {
+        const db = await createPolicyTestClient(
+            `
+type Auth {
+    x Int
+    @@auth
+}
+
+model Foo {
+    id Int @id @default(autoincrement())
+    x  Int
+    @@allow('create', x == auth().x)
+    @@allow('read', true)
+}
+`,
+        );
+        await expect(db.foo.create({ data: { x: 0 } })).toBeRejectedByPolicy();
+        await expect(db.$setAuth({ x: 0 }).foo.create({ data: { x: 1 } })).toBeRejectedByPolicy();
+        await expect(db.$setAuth({ x: 1 }).foo.create({ data: { x: 1 } })).resolves.toMatchObject({ x: 1 });
+    });
+
+    it('works with owned to-one relation reference', async () => {
+        const db = await createPolicyTestClient(
+            `
+model User {
+    id Int @id
+    profile Profile?
+    @@allow('all', true)
+}
+
+model Profile {
+    id Int @id
+    user User? @relation(fields: [userId], references: [id])
+    userId Int? @unique
+
+    @@deny('all', auth() == null)
+    @@allow('create', user.id == auth().id)
+    @@allow('read', true)
+}
+            `,
+        );
+
+        await db.user.create({ data: { id: 1 } });
+        await expect(db.profile.create({ data: { id: 1 } })).toBeRejectedByPolicy();
+        await expect(db.$setAuth({ id: 0 }).profile.create({ data: { id: 1, userId: 1 } })).toBeRejectedByPolicy();
+        await expect(db.$setAuth({ id: 1 }).profile.create({ data: { id: 1, userId: 1 } })).resolves.toMatchObject({
+            id: 1,
+        });
+
+        await expect(db.profile.create({ data: { id: 2, user: { create: { id: 2 } } } })).toBeRejectedByPolicy();
+        await expect(db.user.findUnique({ where: { id: 2 } })).toResolveNull();
+        await expect(
+            db
+                .$setAuth({ id: 2 })
+                .profile.create({ data: { id: 2, user: { create: { id: 2 } } }, include: { user: true } }),
+        ).resolves.toMatchObject({
+            id: 2,
+            user: {
+                id: 2,
+            },
+        });
+
+        await db.user.create({ data: { id: 3 } });
+        await expect(
+            db.$setAuth({ id: 2 }).profile.create({ data: { id: 3, user: { connect: { id: 3 } } } }),
+        ).toBeRejectedByPolicy();
+        await expect(
+            db.$setAuth({ id: 3 }).profile.create({ data: { id: 3, user: { connect: { id: 3 } } } }),
+        ).toResolveTruthy();
+
+        await expect(db.$setAuth({ id: 4 }).profile.create({ data: { id: 2, userId: 4 } })).toBeRejectedByPolicy();
+    });
+});

--- a/packages/runtime/test/policy/crud/dumb-rules.test.ts
+++ b/packages/runtime/test/policy/crud/dumb-rules.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { createPolicyTestClient } from '../utils';
+
+describe('Policy dumb rules tests', () => {
+    it('works with create dumb rules', async () => {
+        const db = await createPolicyTestClient(
+            `
+model A {
+    id Int @id @default(autoincrement())
+    x  Int
+    @@allow('create', 1 > 0)
+    @@allow('read', true)
+}
+
+model B {
+    id Int @id @default(autoincrement())
+    x  Int
+    @@allow('create', 0 > 1)
+    @@allow('read', true)
+}
+
+model C {
+    id Int @id @default(autoincrement())
+    x  Int
+    @@allow('create', true)
+    @@allow('read', true)
+}
+
+model D {
+    id Int @id @default(autoincrement())
+    x  Int
+    @@allow('create', false)
+    @@allow('read', true)
+}
+`,
+        );
+        await expect(db.a.create({ data: { x: 0 } })).resolves.toMatchObject({ x: 0 });
+        await expect(db.b.create({ data: { x: 0 } })).toBeRejectedByPolicy();
+        await expect(db.c.create({ data: { x: 0 } })).resolves.toMatchObject({ x: 0 });
+        await expect(db.d.create({ data: { x: 0 } })).toBeRejectedByPolicy();
+    });
+});

--- a/packages/runtime/test/policy/ref-equality.test.ts
+++ b/packages/runtime/test/policy/ref-equality.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { createPolicyTestClient } from './utils';
+
+describe('Reference Equality Tests', () => {
+    it('works with auth equality', async () => {
+        const db = await createPolicyTestClient(
+            `
+model User {
+    id1 Int
+    id2 Int
+    posts Post[]
+    @@id([id1, id2])
+    @@allow('all', auth() == this)
+}
+
+model Post {
+    id Int @id @default(autoincrement())
+    title String
+    authorId1 Int
+    authorId2 Int
+    author User @relation(fields: [authorId1, authorId2], references: [id1, id2])
+    @@allow('all', auth() == author)
+}
+            `,
+            { log: ['query'] },
+        );
+
+        await expect(
+            db.user.create({
+                data: { id1: 1, id2: 2 },
+            }),
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.$setAuth({ id1: 1, id2: 2 }).user.create({
+                data: { id1: 1, id2: 2 },
+            }),
+        ).resolves.toMatchObject({ id1: 1, id2: 2 });
+    });
+});

--- a/packages/runtime/test/utils.ts
+++ b/packages/runtime/test/utils.ts
@@ -3,7 +3,7 @@ import { loadDocument } from '@zenstackhq/language';
 import { PrismaSchemaGenerator } from '@zenstackhq/sdk';
 import { createTestProject, generateTsSchema } from '@zenstackhq/testtools';
 import SQLite from 'better-sqlite3';
-import { PostgresDialect, SqliteDialect } from 'kysely';
+import { PostgresDialect, SqliteDialect, type LogEvent } from 'kysely';
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -191,4 +191,8 @@ export async function createTestClient<Schema extends SchemaDef>(
     }
 
     return client;
+}
+
+export function testLogger(e: LogEvent) {
+    console.log(e.query.sql, e.query.parameters);
 }

--- a/packages/sdk/src/model-utils.ts
+++ b/packages/sdk/src/model-utils.ts
@@ -2,6 +2,7 @@ import {
     isDataModel,
     isLiteralExpr,
     isModel,
+    isTypeDef,
     Model,
     type AstNode,
     type Attribute,
@@ -102,7 +103,7 @@ export function resolved<T extends AstNode>(ref: Reference<T>): T {
 
 export function getAuthDecl(model: Model) {
     let found = model.declarations.find(
-        (d) => isDataModel(d) && d.attributes.some((attr) => attr.decl.$refText === '@@auth'),
+        (d) => (isDataModel(d) || isTypeDef(d)) && d.attributes.some((attr) => attr.decl.$refText === '@@auth'),
     );
     if (!found) {
         found = model.declarations.find((d) => isDataModel(d) && d.name === 'User');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Defaults (including updatedAt and JSON defaults) are now auto-applied on create/createMany.
  - Expression utility: added logical negation (not).

- **Bug Fixes**
  - Create-policy checks tightened to cover missing and DB-generated fields.
  - Non-owned relation references in create rules are rejected.
  - Improved auth-based equality handling (including composite keys).

- **Refactor**
  - Plugin hook args simplified: on-kysely-query now supplies client (use client.$qb) instead of kysely.

- **Tests**
  - New policy and hook tests added; test SQL logger helper included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->