### PR TITLE
fix: format zod errors, issue with "this" member access

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -73,7 +73,8 @@
         "toposort": "^2.0.2",
         "ts-pattern": "catalog:",
         "ulid": "^3.0.0",
-        "uuid": "^11.0.5"
+        "uuid": "^11.0.5",
+        "zod-validation-error": "catalog:"
     },
     "peerDependencies": {
         "better-sqlite3": "^12.2.0",

--- a/packages/runtime/src/client/crud/validator.ts
+++ b/packages/runtime/src/client/crud/validator.ts
@@ -6,6 +6,7 @@ import { z, ZodType } from 'zod';
 import { type BuiltinType, type EnumDef, type FieldDef, type GetModels, type SchemaDef } from '../../schema';
 import { enumerate } from '../../utils/enumerate';
 import { extractFields } from '../../utils/object-utils';
+import { formatError } from '../../utils/zod-utils';
 import { AGGREGATE_OPERATORS, LOGICAL_COMBINATORS, NUMERIC_FIELD_TYPES } from '../constants';
 import {
     type AggregateArgs,
@@ -185,7 +186,7 @@ export class InputValidator<Schema extends SchemaDef> {
         }
         const { error } = schema.safeParse(args);
         if (error) {
-            throw new InputValidationError(`Invalid ${operation} args: ${error.message}`, error);
+            throw new InputValidationError(`Invalid ${operation} args: ${formatError(error)}`, error);
         }
         return args as T;
     }

--- a/packages/runtime/src/utils/zod-utils.ts
+++ b/packages/runtime/src/utils/zod-utils.ts
@@ -1,0 +1,14 @@
+import { ZodError } from 'zod';
+import { fromError as fromError3 } from 'zod-validation-error/v3';
+import { fromError as fromError4 } from 'zod-validation-error/v4';
+
+/**
+ * Format ZodError into a readable string
+ */
+export function formatError(error: ZodError): string {
+    if ('_zod' in error) {
+        return fromError4(error).toString();
+    } else {
+        return fromError3(error).toString();
+    }
+}

--- a/packages/runtime/test/client-api/group-by.test.ts
+++ b/packages/runtime/test/client-api/group-by.test.ts
@@ -269,7 +269,7 @@ describe.each(createClientSpecs(PG_DB_NAME))('Client groupBy tests', ({ createCl
                     age: 10,
                 },
             }),
-        ).rejects.toThrow(/must be in \\"by\\"/);
+        ).rejects.toThrow(/must be in "by"/);
     });
 
     it('complains about fields in orderBy that are not in by', async () => {
@@ -280,6 +280,6 @@ describe.each(createClientSpecs(PG_DB_NAME))('Client groupBy tests', ({ createCl
                     age: 'asc',
                 },
             }),
-        ).rejects.toThrow(/must be in \\"by\\"/);
+        ).rejects.toThrow(/must be in "by"/);
     });
 });

--- a/packages/runtime/test/utils.ts
+++ b/packages/runtime/test/utils.ts
@@ -152,7 +152,7 @@ export async function createTestClient<Schema extends SchemaDef>(
         fs.writeFileSync(path.resolve(workDir!, 'schema.prisma'), prismaSchemaText);
         execSync('npx prisma db push --schema ./schema.prisma --skip-generate --force-reset', {
             cwd: workDir,
-            stdio: 'inherit',
+            stdio: 'ignore',
         });
     } else {
         if (provider === 'postgresql') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ catalogs:
     typescript:
       specifier: ^5.8.0
       version: 5.8.3
+    zod-validation-error:
+      specifier: ^4.0.1
+      version: 4.0.1
 
 importers:
 
@@ -299,6 +302,9 @@ importers:
       uuid:
         specifier: ^11.0.5
         version: 11.0.5
+      zod-validation-error:
+        specifier: 'catalog:'
+        version: 4.0.1(zod@3.25.76)
     devDependencies:
       '@types/better-sqlite3':
         specifier: ^7.6.13
@@ -2711,6 +2717,12 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-validation-error@4.0.1:
+    resolution: {integrity: sha512-F3rdaCOHs5ViJ5YTz5zzRtfkQdMdIeKudJAoxy7yB/2ZMEHw73lmCAcQw11r7++20MyGl4WV59EVh7A9rNAyog==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -4790,5 +4802,9 @@ snapshots:
   yaml@2.8.0: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-validation-error@4.0.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
 
   zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,3 +13,4 @@ catalog:
     '@types/node': ^20.17.24
     tmp: ^0.2.3
     '@types/tmp': ^0.2.6
+    'zod-validation-error': ^4.0.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - More informative validation error messages for invalid inputs.
  - Corrected policy evaluation for auth comparisons across ID fields, improving accuracy in equality/inequality checks.

- Tests
  - Expanded coverage for nested create/update/delete/upsert and batch updates under policy rules.
  - Adjusted error message expectations in group-by tests.
  - Silenced Prisma push output during test setup.

- Chores
  - Added zod-validation-error dependency and workspace catalog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->