### PR TITLE
feat(policy): support read filtering for update with "from" and delete with "using"

### DIFF
--- a/packages/language/src/validators/expression-validator.ts
+++ b/packages/language/src/validators/expression-validator.ts
@@ -108,10 +108,12 @@ export default class ExpressionValidator implements AstValidator<Expression> {
                     supportedShapes = ['Boolean', 'Any'];
                 }
 
+                const leftResolvedDecl = expr.left.$resolvedType?.decl;
+                const rightResolvedDecl = expr.right.$resolvedType?.decl;
+
                 if (
-                    expr.left.$resolvedType &&
-                    (typeof expr.left.$resolvedType?.decl !== 'string' ||
-                        !supportedShapes.includes(expr.left.$resolvedType.decl))
+                    leftResolvedDecl &&
+                    (typeof leftResolvedDecl !== 'string' || !supportedShapes.includes(leftResolvedDecl))
                 ) {
                     accept('error', `invalid operand type for "${expr.operator}" operator`, {
                         node: expr.left,
@@ -119,9 +121,8 @@ export default class ExpressionValidator implements AstValidator<Expression> {
                     return;
                 }
                 if (
-                    expr.right.$resolvedType &&
-                    (typeof expr.right.$resolvedType?.decl !== 'string' ||
-                        !supportedShapes.includes(expr.right.$resolvedType.decl))
+                    rightResolvedDecl &&
+                    (typeof rightResolvedDecl !== 'string' || !supportedShapes.includes(rightResolvedDecl))
                 ) {
                     accept('error', `invalid operand type for "${expr.operator}" operator`, {
                         node: expr.right,
@@ -130,14 +131,11 @@ export default class ExpressionValidator implements AstValidator<Expression> {
                 }
 
                 // DateTime comparison is only allowed between two DateTime values
-                if (expr.left.$resolvedType?.decl === 'DateTime' && expr.right.$resolvedType?.decl !== 'DateTime') {
+                if (leftResolvedDecl === 'DateTime' && rightResolvedDecl && rightResolvedDecl !== 'DateTime') {
                     accept('error', 'incompatible operand types', {
                         node: expr,
                     });
-                } else if (
-                    expr.right.$resolvedType?.decl === 'DateTime' &&
-                    expr.left.$resolvedType?.decl !== 'DateTime'
-                ) {
+                } else if (rightResolvedDecl === 'DateTime' && leftResolvedDecl && leftResolvedDecl !== 'DateTime') {
                     accept('error', 'incompatible operand types', {
                         node: expr,
                     });

--- a/packages/language/src/validators/expression-validator.ts
+++ b/packages/language/src/validators/expression-validator.ts
@@ -109,8 +109,9 @@ export default class ExpressionValidator implements AstValidator<Expression> {
                 }
 
                 if (
-                    typeof expr.left.$resolvedType?.decl !== 'string' ||
-                    !supportedShapes.includes(expr.left.$resolvedType.decl)
+                    expr.left.$resolvedType &&
+                    (typeof expr.left.$resolvedType?.decl !== 'string' ||
+                        !supportedShapes.includes(expr.left.$resolvedType.decl))
                 ) {
                     accept('error', `invalid operand type for "${expr.operator}" operator`, {
                         node: expr.left,
@@ -118,8 +119,9 @@ export default class ExpressionValidator implements AstValidator<Expression> {
                     return;
                 }
                 if (
-                    typeof expr.right.$resolvedType?.decl !== 'string' ||
-                    !supportedShapes.includes(expr.right.$resolvedType.decl)
+                    expr.right.$resolvedType &&
+                    (typeof expr.right.$resolvedType?.decl !== 'string' ||
+                        !supportedShapes.includes(expr.right.$resolvedType.decl))
                 ) {
                     accept('error', `invalid operand type for "${expr.operator}" operator`, {
                         node: expr.right,
@@ -128,13 +130,13 @@ export default class ExpressionValidator implements AstValidator<Expression> {
                 }
 
                 // DateTime comparison is only allowed between two DateTime values
-                if (expr.left.$resolvedType.decl === 'DateTime' && expr.right.$resolvedType.decl !== 'DateTime') {
+                if (expr.left.$resolvedType?.decl === 'DateTime' && expr.right.$resolvedType?.decl !== 'DateTime') {
                     accept('error', 'incompatible operand types', {
                         node: expr,
                     });
                 } else if (
-                    expr.right.$resolvedType.decl === 'DateTime' &&
-                    expr.left.$resolvedType.decl !== 'DateTime'
+                    expr.right.$resolvedType?.decl === 'DateTime' &&
+                    expr.left.$resolvedType?.decl !== 'DateTime'
                 ) {
                     accept('error', 'incompatible operand types', {
                         node: expr,

--- a/packages/runtime/src/client/crud/dialects/postgresql.ts
+++ b/packages/runtime/src/client/crud/dialects/postgresql.ts
@@ -14,10 +14,10 @@ import type { FindArgs } from '../../crud-types';
 import {
     buildJoinPairs,
     getDelegateDescendantModels,
-    getIdFields,
     getManyToManyRelation,
     isRelationField,
     requireField,
+    requireIdFields,
     requireModel,
 } from '../../query-utils';
 import { BaseCrudDialect } from './base-dialect';
@@ -157,8 +157,8 @@ export class PostgresCrudDialect<Schema extends SchemaDef> extends BaseCrudDiale
         const m2m = getManyToManyRelation(this.schema, model, relationField);
         if (m2m) {
             // many-to-many relation
-            const parentIds = getIdFields(this.schema, model);
-            const relationIds = getIdFields(this.schema, relationModel);
+            const parentIds = requireIdFields(this.schema, model);
+            const relationIds = requireIdFields(this.schema, relationModel);
             invariant(parentIds.length === 1, 'many-to-many relation must have exactly one id field');
             invariant(relationIds.length === 1, 'many-to-many relation must have exactly one id field');
             query = query.where((eb) =>

--- a/packages/runtime/src/client/crud/dialects/sqlite.ts
+++ b/packages/runtime/src/client/crud/dialects/sqlite.ts
@@ -14,10 +14,10 @@ import { DELEGATE_JOINED_FIELD_PREFIX } from '../../constants';
 import type { FindArgs } from '../../crud-types';
 import {
     getDelegateDescendantModels,
-    getIdFields,
     getManyToManyRelation,
     getRelationForeignKeyFieldPairs,
     requireField,
+    requireIdFields,
     requireModel,
 } from '../../query-utils';
 import { BaseCrudDialect } from './base-dialect';
@@ -213,8 +213,8 @@ export class SqliteCrudDialect<Schema extends SchemaDef> extends BaseCrudDialect
         const m2m = getManyToManyRelation(this.schema, model, relationField);
         if (m2m) {
             // many-to-many relation
-            const parentIds = getIdFields(this.schema, model);
-            const relationIds = getIdFields(this.schema, relationModel);
+            const parentIds = requireIdFields(this.schema, model);
+            const relationIds = requireIdFields(this.schema, relationModel);
             invariant(parentIds.length === 1, 'many-to-many relation must have exactly one id field');
             invariant(relationIds.length === 1, 'many-to-many relation must have exactly one id field');
             selectModelQuery = selectModelQuery.where((eb) =>

--- a/packages/runtime/src/client/query-utils.ts
+++ b/packages/runtime/src/client/query-utils.ts
@@ -55,7 +55,7 @@ export function requireField(schema: SchemaDef, modelOrType: string, field: stri
 }
 
 export function getIdFields<Schema extends SchemaDef>(schema: SchemaDef, model: GetModels<Schema>) {
-    const modelDef = requireModel(schema, model);
+    const modelDef = getModel(schema, model);
     return modelDef?.idFields;
 }
 
@@ -231,7 +231,7 @@ export function buildJoinPairs(
 }
 
 export function makeDefaultOrderBy<Schema extends SchemaDef>(schema: SchemaDef, model: string) {
-    const idFields = getIdFields(schema, model);
+    const idFields = requireIdFields(schema, model);
     return idFields.map((f) => ({ [f]: 'asc' }) as OrderBy<Schema, GetModels<Schema>, true, false>);
 }
 
@@ -318,7 +318,7 @@ export function safeJSONStringify(value: unknown) {
 }
 
 export function extractIdFields(entity: any, schema: SchemaDef, model: string) {
-    const idFields = getIdFields(schema, model);
+    const idFields = requireIdFields(schema, model);
     return extractFields(entity, idFields);
 }
 

--- a/packages/runtime/src/client/query-utils.ts
+++ b/packages/runtime/src/client/query-utils.ts
@@ -56,7 +56,7 @@ export function requireField(schema: SchemaDef, modelOrType: string, field: stri
 
 export function getIdFields<Schema extends SchemaDef>(schema: SchemaDef, model: GetModels<Schema>) {
     const modelDef = requireModel(schema, model);
-    return modelDef?.idFields as GetModels<Schema>[];
+    return modelDef?.idFields;
 }
 
 export function requireIdFields(schema: SchemaDef, model: string) {

--- a/packages/runtime/src/plugins/policy/policy-handler.ts
+++ b/packages/runtime/src/plugins/policy/policy-handler.ts
@@ -34,7 +34,7 @@ import { getCrudDialect } from '../../client/crud/dialects';
 import type { BaseCrudDialect } from '../../client/crud/dialects/base-dialect';
 import { InternalError, QueryError } from '../../client/errors';
 import type { ProceedKyselyQueryFunction } from '../../client/plugin';
-import { getIdFields, requireField, requireModel } from '../../client/query-utils';
+import { requireField, requireIdFields, requireModel } from '../../client/query-utils';
 import { ExpressionUtils, type BuiltinType, type Expression, type GetModels, type SchemaDef } from '../../schema';
 import { ColumnCollector } from './column-collector';
 import { RejectedByPolicyError } from './errors';
@@ -217,7 +217,7 @@ export class PolicyHandler<Schema extends SchemaDef> extends OperationNodeTransf
         } else {
             // only return ID fields, that's enough for reading back the inserted row
             const { mutationModel } = this.getMutationModel(node);
-            const idFields = getIdFields(this.client.$schema, mutationModel);
+            const idFields = requireIdFields(this.client.$schema, mutationModel);
             return {
                 ...result,
                 returning: ReturningNode.create(
@@ -274,7 +274,7 @@ export class PolicyHandler<Schema extends SchemaDef> extends OperationNodeTransf
             return true;
         }
         const { mutationModel } = this.getMutationModel(node);
-        const idFields = getIdFields(this.client.$schema, mutationModel);
+        const idFields = requireIdFields(this.client.$schema, mutationModel);
         const collector = new ColumnCollector();
         const selectedColumns = collector.collect(node.returning);
         return selectedColumns.every((c) => idFields.includes(c));
@@ -448,7 +448,7 @@ export class PolicyHandler<Schema extends SchemaDef> extends OperationNodeTransf
     }
 
     private buildIdConditions(table: string, rows: any[]): OperationNode {
-        const idFields = getIdFields(this.client.$schema, table);
+        const idFields = requireIdFields(this.client.$schema, table);
         return disjunction(
             this.dialect,
             rows.map((row) =>

--- a/packages/runtime/test/policy/crud/read.test.ts
+++ b/packages/runtime/test/policy/crud/read.test.ts
@@ -244,5 +244,372 @@ model Bar {
             await db.foo.update({ where: { id: 1 }, data: { bars: { create: { id: 2, y: 1 } } } });
             await expect(db.foo.findMany()).resolves.toHaveLength(1);
         });
+
+        it('works with counting relations', async () => {
+            const db = await createPolicyTestClient(
+                `
+model Foo {
+    id Int @id
+    bars Bar[]
+    @@allow('all', true)
+}
+
+model Bar {
+    id Int @id
+    y  Int
+    foo Foo? @relation(fields: [fooId], references: [id])
+    fooId Int?
+    @@allow('create,update', true)
+    @@allow('read', y > 0)
+}
+`,
+            );
+
+            await db.$unuseAll().foo.create({
+                data: {
+                    id: 1,
+                    bars: {
+                        create: [
+                            { id: 1, y: 0 },
+                            { id: 2, y: 1 },
+                        ],
+                    },
+                },
+            });
+            await expect(
+                db.foo.findFirst({ where: { id: 1 }, select: { _count: { select: { bars: true } } } }),
+            ).resolves.toMatchObject({ _count: { bars: 1 } });
+        });
+    });
+
+    describe('Count tests', () => {
+        it('works with top-level count', async () => {
+            const db = await createPolicyTestClient(
+                `
+model Foo {
+    id Int @id
+    x  Int
+    name String
+    @@allow('create', true)
+    @@allow('read', x > 0)
+}
+`,
+            );
+
+            await db.$unuseAll().foo.create({ data: { id: 1, x: 0, name: 'Foo1' } });
+            await db.$unuseAll().foo.create({ data: { id: 2, x: 0, name: 'Foo2' } });
+            await expect(db.foo.count()).resolves.toBe(0);
+            await expect(db.foo.count({ select: { _all: true, name: true } })).resolves.toEqual({ _all: 0, name: 0 });
+
+            await db.$unuseAll().foo.update({ where: { id: 1 }, data: { x: 1 } });
+            await expect(db.foo.count()).resolves.toBe(1);
+            await expect(db.foo.count({ select: { _all: true, name: true } })).resolves.toEqual({ _all: 1, name: 1 });
+        });
+    });
+
+    describe('Aggregate tests', () => {
+        it('respects read policies', async () => {
+            const db = await createPolicyTestClient(
+                `
+model Foo {
+    id Int @id
+    x  Int
+    @@allow('create', true)
+    @@allow('read', x > 0)
+}
+`,
+            );
+
+            await db.$unuseAll().foo.create({ data: { id: 1, x: 0 } });
+            await db.$unuseAll().foo.create({ data: { id: 2, x: 1 } });
+            await db.$unuseAll().foo.create({ data: { id: 3, x: 3 } });
+
+            await expect(
+                db.foo.aggregate({
+                    _count: true,
+                    _sum: { x: true },
+                    _avg: { x: true },
+                    _min: { x: true },
+                    _max: { x: true },
+                }),
+            ).resolves.toEqual({
+                _count: 2,
+                _sum: { x: 4 },
+                _avg: { x: 2 },
+                _min: { x: 1 },
+                _max: { x: 3 },
+            });
+        });
+    });
+
+    describe('GroupBy tests', () => {
+        it('respects read policies', async () => {
+            const db = await createPolicyTestClient(
+                `
+model Foo {
+    id Int @id
+    x  Int
+    y  Int
+    @@allow('create', true)
+    @@allow('read', x > 0)
+}
+`,
+            );
+
+            await db.$unuseAll().foo.create({ data: { id: 1, x: 0, y: 1 } });
+            await db.$unuseAll().foo.create({ data: { id: 2, x: 1, y: 1 } });
+            await db.$unuseAll().foo.create({ data: { id: 3, x: 3, y: 2 } });
+            await db.$unuseAll().foo.create({ data: { id: 4, x: 5, y: 2 } });
+
+            await expect(
+                db.foo.groupBy({
+                    by: ['y'],
+                    _count: { _all: true },
+                    _sum: { x: true },
+                    _avg: { x: true },
+                    _min: { x: true },
+                    _max: { x: true },
+                    orderBy: { y: 'asc' },
+                }),
+            ).resolves.toEqual([
+                {
+                    y: 1,
+                    _count: { _all: 1 },
+                    _sum: { x: 1 },
+                    _avg: { x: 1 },
+                    _min: { x: 1 },
+                    _max: { x: 1 },
+                },
+                {
+                    y: 2,
+                    _count: { _all: 2 },
+                    _sum: { x: 8 },
+                    _avg: { x: 4 },
+                    _min: { x: 3 },
+                    _max: { x: 5 },
+                },
+            ]);
+        });
+    });
+
+    describe('Query builder tests', () => {
+        it('works with simple selects', async () => {
+            const db = await createPolicyTestClient(
+                `
+model Foo {
+    id Int @id
+    x  Int
+    @@allow('create', true)
+    @@allow('read', x > 0)
+}
+`,
+            );
+
+            await db.$unuseAll().foo.create({ data: { id: 1, x: 0 } });
+            await db.$unuseAll().foo.create({ data: { id: 2, x: 1 } });
+
+            await expect(db.$qb.selectFrom('Foo').selectAll().execute()).resolves.toHaveLength(1);
+            await expect(db.$qb.selectFrom('Foo as f').selectAll().execute()).resolves.toHaveLength(1);
+            await expect(db.$qb.selectFrom('Foo').selectAll().execute()).resolves.toHaveLength(1);
+            await expect(db.$qb.selectFrom('Foo').where('id', '=', 1).selectAll().execute()).resolves.toHaveLength(0);
+
+            // nested query
+            await expect(
+                db.$qb
+                    .selectFrom((eb: any) => eb.selectFrom('Foo').selectAll().as('f'))
+                    .selectAll()
+                    .execute(),
+            ).resolves.toHaveLength(1);
+            await expect(
+                db.$qb
+                    .selectFrom((eb: any) => eb.selectFrom('Foo').selectAll().as('f'))
+                    .selectAll()
+                    .where('f.id', '=', 1)
+                    .execute(),
+            ).resolves.toHaveLength(0);
+        });
+
+        it('works with joins', async () => {
+            const db = await createPolicyTestClient(
+                `
+model Foo {
+    id Int @id
+    x  Int
+    bars Bar[]
+    @@allow('create', true)
+    @@allow('read', x > 0)
+}
+
+model Bar {
+    id Int @id
+    y  Int
+    foo Foo? @relation(fields: [fooId], references: [id])
+    fooId Int?
+    @@allow('create', true)
+    @@allow('read', y > 0)
+}
+`,
+            );
+
+            await db.$unuseAll().foo.create({
+                data: {
+                    id: 1,
+                    x: 1,
+                    bars: {
+                        create: [
+                            { id: 1, y: 0 },
+                            { id: 2, y: 1 },
+                        ],
+                    },
+                },
+            });
+            await db.$unuseAll().foo.create({
+                data: {
+                    id: 2,
+                    x: 0,
+                    bars: {
+                        create: { id: 3, y: 1 },
+                    },
+                },
+            });
+
+            // direct join
+            await expect(
+                db.$qb.selectFrom('Foo').innerJoin('Bar', 'Bar.fooId', 'Foo.id').select(['Foo.id', 'x', 'y']).execute(),
+            ).resolves.toEqual([expect.objectContaining({ id: 1, x: 1, y: 1 })]);
+
+            // through alias
+            await expect(
+                db.$qb
+                    .selectFrom('Foo as f')
+                    .innerJoin(
+                        (eb: any) => eb.selectFrom('Bar').selectAll().as('b'),
+                        (join: any) => join.onRef('b.fooId', '=', 'f.id'),
+                    )
+                    .select(['f.id', 'x', 'y'])
+                    .execute(),
+            ).resolves.toEqual([expect.objectContaining({ id: 1, x: 1, y: 1 })]);
+        });
+
+        it('works with implicit cross join', async () => {
+            const db = await createPolicyTestClient(
+                `
+model Foo {
+    id Int @id
+    x  Int
+    @@allow('create', true)
+    @@allow('read', x > 0)
+}
+
+model Bar {
+    id Int @id
+    y  Int
+    @@allow('create', true)
+    @@allow('read', y > 0)
+}
+`,
+                { provider: 'postgresql', dbName: 'policy-test-implicit-cross-join' },
+            );
+
+            await db.$unuseAll().foo.createMany({
+                data: [
+                    { id: 1, x: 1 },
+                    { id: 2, x: 0 },
+                ],
+            });
+            await db.$unuseAll().bar.createMany({
+                data: [
+                    { id: 1, y: 1 },
+                    { id: 2, y: 0 },
+                ],
+            });
+
+            await expect(
+                db.$qb.selectFrom(['Foo', 'Bar']).select(['Foo.id as fooId', 'Bar.id as barId', 'x', 'y']).execute(),
+            ).resolves.toEqual([
+                {
+                    fooId: 1,
+                    barId: 1,
+                    x: 1,
+                    y: 1,
+                },
+            ]);
+        });
+
+        it('works with update from', async () => {
+            const db = await createPolicyTestClient(
+                `
+model Foo {
+    id Int @id
+    x  Int
+    @@allow('all', true)
+}
+
+model Bar {
+    id Int @id
+    y  Int
+    @@allow('read', y > 0)
+}
+`,
+            );
+
+            await db.$unuseAll().foo.create({ data: { id: 1, x: 1 } });
+            await db.$unuseAll().bar.create({ data: { id: 1, y: 0 } });
+
+            // update with from, only one row is visible
+            await expect(
+                db.$qb
+                    .updateTable('Foo')
+                    .from('Bar as bar')
+                    .whereRef('Foo.id', '=', 'bar.id')
+                    .set((eb: any) => ({ x: eb.ref('bar.y') }))
+                    .executeTakeFirst(),
+            ).resolves.toMatchObject({ numUpdatedRows: 0n });
+            await expect(db.foo.findFirst()).resolves.toMatchObject({ x: 1 });
+
+            await db.$unuseAll().bar.update({ where: { id: 1 }, data: { y: 2 } });
+            await expect(
+                db.$qb
+                    .updateTable('Foo')
+                    .from('Bar as bar')
+                    .whereRef('Foo.id', '=', 'bar.id')
+                    .set((eb: any) => ({ x: eb.ref('bar.y') }))
+                    .executeTakeFirst(),
+            ).resolves.toMatchObject({ numUpdatedRows: 1n });
+            await expect(db.foo.findFirst()).resolves.toMatchObject({ x: 2 });
+        });
+
+        it('works with delete using', async () => {
+            const db = await createPolicyTestClient(
+                `
+model Foo {
+    id Int @id
+    x  Int
+    @@allow('all', true)
+}
+
+model Bar {
+    id Int @id
+    y  Int
+    @@allow('read', y > 0)
+}
+`,
+                { provider: 'postgresql', dbName: 'policy-test-delete-using' },
+            );
+
+            await db.$unuseAll().foo.create({ data: { id: 1, x: 1 } });
+            await db.$unuseAll().bar.create({ data: { id: 1, y: 0 } });
+
+            await expect(
+                db.$qb.deleteFrom('Foo').using('Bar as bar').whereRef('Foo.id', '=', 'bar.id').executeTakeFirst(),
+            ).resolves.toMatchObject({ numDeletedRows: 0n });
+            await expect(db.foo.findFirst()).resolves.toBeTruthy();
+
+            await db.$unuseAll().bar.update({ where: { id: 1 }, data: { y: 2 } });
+            await expect(
+                db.$qb.deleteFrom('Foo').using('Bar as bar').whereRef('Foo.id', '=', 'bar.id').executeTakeFirst(),
+            ).resolves.toMatchObject({ numDeletedRows: 1n });
+            await expect(db.foo.findFirst()).resolves.toBeNull();
+        });
     });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Read policies now apply across multi-table FROMs and joins, and joined updates/deletes; joins are filtered via nested subqueries.

* **Bug Fixes**
  * Avoids false "invalid operand type" errors when operand types are unresolved; safer DateTime compatibility checks.
  * Enforces presence of model ID fields earlier (missing IDs now surface as errors).

* **Tests**
  * Added tests ensuring _count on to-many relations only includes permitted records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->