### PR TITLE
feat(policy): many-to-many and self-relation support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -99,9 +99,8 @@
 - [ ] Validation
 - [ ] Access Policy
     - [ ] Short-circuit pre-create check for scalar-field only policies
-    - [ ] Inject "replace into"
-    - [ ] Inject "on conflict do update"
-    - [ ] Inject "insert into select from"
+    - [x] Inject "on conflict do update"
+    - [x] `check` function
 - [x] Migration
 - [ ] Databases
     - [x] SQLite

--- a/packages/common-helpers/src/index.ts
+++ b/packages/common-helpers/src/index.ts
@@ -4,3 +4,4 @@ export * from './param-case';
 export * from './sleep';
 export * from './tiny-invariant';
 export * from './upper-case-first';
+export * from './zip';

--- a/packages/common-helpers/src/zip.ts
+++ b/packages/common-helpers/src/zip.ts
@@ -1,5 +1,5 @@
 /**
- * Zipped two arrays into an array of tuples.
+ * Zips two arrays into an array of tuples.
  */
 export function zip<T, U>(arr1: T[], arr2: U[]): Array<[T, U]> {
     const length = Math.min(arr1.length, arr2.length);

--- a/packages/common-helpers/src/zip.ts
+++ b/packages/common-helpers/src/zip.ts
@@ -1,0 +1,11 @@
+/**
+ * Zipped two arrays into an array of tuples.
+ */
+export function zip<T, U>(arr1: T[], arr2: U[]): Array<[T, U]> {
+    const length = Math.min(arr1.length, arr2.length);
+    const result: Array<[T, U]> = [];
+    for (let i = 0; i < length; i++) {
+        result.push([arr1[i]!, arr2[i]!]);
+    }
+    return result;
+}

--- a/packages/runtime/src/client/crud-types.ts
+++ b/packages/runtime/src/client/crud-types.ts
@@ -452,7 +452,7 @@ export type OmitInput<Schema extends SchemaDef, Model extends GetModels<Schema>>
 
 export type SelectIncludeOmit<Schema extends SchemaDef, Model extends GetModels<Schema>, AllowCount extends boolean> = {
     select?: SelectInput<Schema, Model, AllowCount, boolean>;
-    include?: IncludeInput<Schema, Model>;
+    include?: IncludeInput<Schema, Model, AllowCount>;
     omit?: OmitInput<Schema, Model>;
 };
 
@@ -463,14 +463,7 @@ export type SelectInput<
     AllowRelation extends boolean = true,
 > = {
     [Key in NonRelationFields<Schema, Model>]?: boolean;
-} & (AllowRelation extends true ? IncludeInput<Schema, Model> : {}) & // relation fields
-    // relation count
-    (AllowCount extends true
-        ? // _count is only allowed if the model has to-many relations
-          HasToManyRelations<Schema, Model> extends true
-            ? { _count?: SelectCount<Schema, Model> }
-            : {}
-        : {});
+} & (AllowRelation extends true ? IncludeInput<Schema, Model, AllowCount> : {});
 
 type SelectCount<Schema extends SchemaDef, Model extends GetModels<Schema>> =
     | boolean
@@ -484,7 +477,11 @@ type SelectCount<Schema extends SchemaDef, Model extends GetModels<Schema>> =
           };
       };
 
-export type IncludeInput<Schema extends SchemaDef, Model extends GetModels<Schema>> = {
+export type IncludeInput<
+    Schema extends SchemaDef,
+    Model extends GetModels<Schema>,
+    AllowCount extends boolean = true,
+> = {
     [Key in RelationFields<Schema, Model>]?:
         | boolean
         | FindArgs<
@@ -498,7 +495,12 @@ export type IncludeInput<Schema extends SchemaDef, Model extends GetModels<Schem
                     ? true
                     : false
           >;
-};
+} & (AllowCount extends true
+    ? // _count is only allowed if the model has to-many relations
+      HasToManyRelations<Schema, Model> extends true
+        ? { _count?: SelectCount<Schema, Model> }
+        : {}
+    : {});
 
 export type Subset<T, U> = {
     [key in keyof T]: key extends keyof U ? T[key] : never;
@@ -674,7 +676,7 @@ export type FindUniqueArgs<Schema extends SchemaDef, Model extends GetModels<Sch
 
 export type CreateArgs<Schema extends SchemaDef, Model extends GetModels<Schema>> = {
     data: CreateInput<Schema, Model>;
-    select?: SelectInput<Schema, Model, true>;
+    select?: SelectInput<Schema, Model>;
     include?: IncludeInput<Schema, Model>;
     omit?: OmitInput<Schema, Model>;
 };
@@ -813,7 +815,7 @@ type NestedCreateManyInput<
 export type UpdateArgs<Schema extends SchemaDef, Model extends GetModels<Schema>> = {
     data: UpdateInput<Schema, Model>;
     where: WhereUniqueInput<Schema, Model>;
-    select?: SelectInput<Schema, Model, true>;
+    select?: SelectInput<Schema, Model>;
     include?: IncludeInput<Schema, Model>;
     omit?: OmitInput<Schema, Model>;
 };
@@ -841,7 +843,7 @@ export type UpsertArgs<Schema extends SchemaDef, Model extends GetModels<Schema>
     create: CreateInput<Schema, Model>;
     update: UpdateInput<Schema, Model>;
     where: WhereUniqueInput<Schema, Model>;
-    select?: SelectInput<Schema, Model, true>;
+    select?: SelectInput<Schema, Model>;
     include?: IncludeInput<Schema, Model>;
     omit?: OmitInput<Schema, Model>;
 };
@@ -958,7 +960,7 @@ type ToOneRelationUpdateInput<
 
 export type DeleteArgs<Schema extends SchemaDef, Model extends GetModels<Schema>> = {
     where: WhereUniqueInput<Schema, Model>;
-    select?: SelectInput<Schema, Model, true>;
+    select?: SelectInput<Schema, Model>;
     include?: IncludeInput<Schema, Model>;
     omit?: OmitInput<Schema, Model>;
 };

--- a/packages/runtime/src/client/crud/dialects/base-dialect.ts
+++ b/packages/runtime/src/client/crud/dialects/base-dialect.ts
@@ -1055,13 +1055,13 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             if (m2m) {
                 // many-to-many relation, count the join table
                 fieldCountQuery = eb
-                    .selectFrom(m2m.joinTable)
-                    .select(eb.fn.countAll().as(`_count$${field}`))
-                    .whereRef(
-                        eb.ref(`${parentAlias}.${m2m.parentPKName}`),
-                        '=',
-                        eb.ref(`${m2m.joinTable}.${m2m.parentFkName}`),
-                    );
+                    .selectFrom(fieldModel)
+                    .innerJoin(m2m.joinTable, (join) =>
+                        join
+                            .onRef(`${m2m.joinTable}.${m2m.otherFkName}`, '=', `${fieldModel}.${m2m.otherPKName}`)
+                            .onRef(`${m2m.joinTable}.${m2m.parentFkName}`, '=', `${parentAlias}.${m2m.parentPKName}`),
+                    )
+                    .select(eb.fn.countAll().as(`_count$${field}`));
             } else {
                 // build a nested query to count the number of records in the relation
                 fieldCountQuery = eb.selectFrom(fieldModel).select(eb.fn.countAll().as(`_count$${field}`));

--- a/packages/runtime/src/client/crud/operations/base.ts
+++ b/packages/runtime/src/client/crud/operations/base.ts
@@ -475,7 +475,7 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
                 entity: rightEntity,
             },
         ].sort((a, b) =>
-            // the implement m2m join table's "A", "B" fk fields' order is determined
+            // the implicit m2m join table's "A", "B" fk fields' order is determined
             // by model name's sort order, and when identical (for self-relations),
             // field name's sort order
             a.model !== b.model ? a.model.localeCompare(b.model) : a.field.localeCompare(b.field),

--- a/packages/runtime/src/client/query-utils.ts
+++ b/packages/runtime/src/client/query-utils.ts
@@ -1,3 +1,4 @@
+import { invariant } from '@zenstackhq/common-helpers';
 import type { Expression, ExpressionBuilder, ExpressionWrapper } from 'kysely';
 import { match } from 'ts-pattern';
 import { ExpressionUtils, type FieldDef, type GetModels, type ModelDef, type SchemaDef } from '../schema';
@@ -259,11 +260,18 @@ export function getManyToManyRelation(schema: SchemaDef, model: string, field: s
             orderedFK = sortedFieldNames[0] === field ? ['A', 'B'] : ['B', 'A'];
         }
 
+        const modelIdFields = requireIdFields(schema, model);
+        invariant(modelIdFields.length === 1, 'Only single-field ID is supported for many-to-many relation');
+        const otherIdFields = requireIdFields(schema, fieldDef.type);
+        invariant(otherIdFields.length === 1, 'Only single-field ID is supported for many-to-many relation');
+
         return {
             parentFkName: orderedFK[0],
+            parentPKName: modelIdFields[0]!,
             otherModel: fieldDef.type,
             otherField: fieldDef.relation.opposite,
             otherFkName: orderedFK[1],
+            otherPKName: otherIdFields[0]!,
             joinTable: fieldDef.relation.name
                 ? `_${fieldDef.relation.name}`
                 : `_${sortedModelNames[0]}To${sortedModelNames[1]}`,

--- a/packages/runtime/src/plugins/policy/expression-transformer.ts
+++ b/packages/runtime/src/plugins/policy/expression-transformer.ts
@@ -44,7 +44,7 @@ import {
     type SchemaDef,
 } from '../../schema';
 import { ExpressionEvaluator } from './expression-evaluator';
-import { conjunction, disjunction, logicalNot, trueNode } from './utils';
+import { conjunction, disjunction, falseNode, logicalNot, trueNode } from './utils';
 
 export type ExpressionTransformerContext<Schema extends SchemaDef> = {
     model: GetModels<Schema>;
@@ -335,7 +335,13 @@ export class ExpressionTransformer<Schema extends SchemaDef> {
     }
 
     private transformValue(value: unknown, type: BuiltinType) {
-        return ValueNode.create(this.dialect.transformPrimitive(value, type, false) ?? null);
+        if (value === true) {
+            return trueNode(this.dialect);
+        } else if (value === false) {
+            return falseNode(this.dialect);
+        } else {
+            return ValueNode.create(this.dialect.transformPrimitive(value, type, false) ?? null);
+        }
     }
 
     @expr('unary')

--- a/packages/runtime/test/policy/migrated/relation-many-to-many-filter.test.ts
+++ b/packages/runtime/test/policy/migrated/relation-many-to-many-filter.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it } from 'vitest';
+import { createPolicyTestClient } from '../utils';
+
+describe('Policy many-to-many relation tests', () => {
+    const model = `
+    model M1 {
+        id String @id @default(uuid())
+        value Int
+        deleted Boolean @default(false)
+        m2 M2[]
+    
+        @@allow('read', !deleted)
+        @@allow('create', true)
+    }
+    
+    model M2 {
+        id String @id @default(uuid())
+        value Int
+        deleted Boolean @default(false)
+        m1 M1[]
+    
+        @@allow('read', !deleted)
+        @@allow('create', true)
+    }
+    `;
+
+    it('some filter', async () => {
+        const db = await createPolicyTestClient(model, { usePrismaPush: true });
+
+        await db.m1.create({
+            data: {
+                id: '1',
+                value: 1,
+                m2: {
+                    create: [
+                        {
+                            id: '1',
+                            value: 1,
+                        },
+                        {
+                            id: '2',
+                            value: 2,
+                            deleted: true,
+                        },
+                    ],
+                },
+            },
+        });
+
+        // m1 -> m2 lookup
+        const r = await db.m1.findFirst({
+            where: {
+                id: '1',
+                m2: {
+                    some: {},
+                },
+            },
+            include: {
+                _count: { select: { m2: true } },
+            },
+        });
+        expect(r._count.m2).toBe(1);
+
+        // m2 -> m1 lookup
+        await expect(
+            db.m2.findFirst({
+                where: {
+                    id: '1',
+                    m1: {
+                        some: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        some: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // m1 with empty m2 list
+        await db.m1.create({
+            data: {
+                id: '2',
+                value: 1,
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        some: {},
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        some: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+    });
+
+    it('none filter', async () => {
+        const db = await createPolicyTestClient(model, { usePrismaPush: true });
+
+        await db.m1.create({
+            data: {
+                id: '1',
+                value: 1,
+                m2: {
+                    create: [
+                        { id: '1', value: 1 },
+                        { id: '2', value: 2, deleted: true },
+                    ],
+                },
+            },
+        });
+
+        // m1 -> m2 lookup
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        none: {},
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // m2 -> m1 lookup
+        await expect(
+            db.m2.findFirst({
+                where: {
+                    m1: {
+                        none: {},
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        none: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with empty m2 list
+        await db.m1.create({
+            data: {
+                id: '2',
+                value: 2,
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        none: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        none: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+
+    it('every filter', async () => {
+        const db = await createPolicyTestClient(model, { usePrismaPush: true });
+
+        await db.m1.create({
+            data: {
+                id: '1',
+                value: 1,
+                m2: {
+                    create: [
+                        { id: '1', value: 1 },
+                        { id: '2', value: 2, deleted: true },
+                    ],
+                },
+            },
+        });
+
+        // m1 -> m2 lookup
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        every: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m2 -> m1 lookup
+        await expect(
+            db.m2.findFirst({
+                where: {
+                    id: '1',
+                    m1: {
+                        every: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        every: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // m1 with empty m2 list
+        await db.m1.create({
+            data: {
+                id: '2',
+                value: 2,
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        every: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        every: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+});

--- a/packages/runtime/test/policy/migrated/relation-many-to-many-filter.test.ts
+++ b/packages/runtime/test/policy/migrated/relation-many-to-many-filter.test.ts
@@ -10,7 +10,7 @@ describe('Policy many-to-many relation tests', () => {
         m2 M2[]
     
         @@allow('read', !deleted)
-        @@allow('create', true)
+        @@allow('create,update', true)
     }
     
     model M2 {
@@ -20,7 +20,7 @@ describe('Policy many-to-many relation tests', () => {
         m1 M1[]
     
         @@allow('read', !deleted)
-        @@allow('create', true)
+        @@allow('create,update', true)
     }
     `;
 

--- a/packages/runtime/test/policy/migrated/relation-one-to-many-filter.test.ts
+++ b/packages/runtime/test/policy/migrated/relation-one-to-many-filter.test.ts
@@ -1,0 +1,1009 @@
+import { describe, expect, it } from 'vitest';
+import { createPolicyTestClient } from '../utils';
+
+describe('Relation one-to-many filter', () => {
+    const model = `
+    model M1 {
+        id String @id @default(uuid())
+        m2 M2[]
+    
+        @@allow('all', true)
+    }
+    
+    model M2 {
+        id String @id @default(uuid())
+        value Int
+        deleted Boolean @default(false)
+        m1 M1 @relation(fields: [m1Id], references:[id])
+        m1Id String
+        m3 M3[]
+    
+        @@allow('read', !deleted)
+        @@allow('create', true)
+    }
+
+    model M3 {
+        id String @id @default(uuid())
+        value Int
+        deleted Boolean @default(false)
+        m2 M2 @relation(fields: [m2Id], references:[id])
+        m2Id String
+
+        @@allow('read', !deleted)
+        @@allow('create', true)
+    }
+    `;
+
+    it('some filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: [
+                        {
+                            value: 1,
+                            m3: {
+                                create: {
+                                    value: 1,
+                                },
+                            },
+                        },
+                        {
+                            value: 2,
+                            deleted: true,
+                            m3: {
+                                create: {
+                                    value: 2,
+                                    deleted: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        some: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        some: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // include clause
+
+        const r = await db.m1.findFirst({
+            where: { id: '1' },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            some: {},
+                        },
+                    },
+                },
+            },
+        });
+        expect(r.m2).toHaveLength(1);
+
+        const r1 = await db.m1.findFirst({
+            where: {
+                id: '1',
+            },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            some: { value: { gt: 1 } },
+                        },
+                    },
+                },
+            },
+        });
+        expect(r1.m2).toHaveLength(0);
+
+        // m1 with empty m2 list
+        await db.m1.create({
+            data: {
+                id: '2',
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        some: {},
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        some: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+    });
+
+    it('none filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: [
+                        {
+                            value: 1,
+                            m3: {
+                                create: {
+                                    value: 1,
+                                },
+                            },
+                        },
+                        {
+                            value: 2,
+                            deleted: true,
+                            m3: {
+                                create: {
+                                    value: 2,
+                                    deleted: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        none: {},
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        none: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // include clause
+
+        const r = await db.m1.findFirst({
+            where: { id: '1' },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            none: {},
+                        },
+                    },
+                },
+            },
+        });
+        expect(r.m2).toHaveLength(0);
+
+        const r1 = await db.m1.findFirst({
+            where: {
+                id: '1',
+            },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            none: { value: { gt: 1 } },
+                        },
+                    },
+                },
+            },
+        });
+        expect(r1.m2).toHaveLength(1);
+
+        // m1 with empty m2 list
+        await db.m1.create({
+            data: {
+                id: '2',
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        none: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        none: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+
+    it('every filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: [
+                        {
+                            value: 1,
+                            m3: {
+                                create: {
+                                    value: 1,
+                                },
+                            },
+                        },
+                        {
+                            value: 2,
+                            deleted: true,
+                            m3: {
+                                create: {
+                                    value: 2,
+                                    deleted: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        every: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        every: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // include clause
+
+        const r = await db.m1.findFirst({
+            where: { id: '1' },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            every: {},
+                        },
+                    },
+                },
+            },
+        });
+        expect(r.m2).toHaveLength(1);
+
+        const r1 = await db.m1.findFirst({
+            where: {
+                id: '1',
+            },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            every: { value: { gt: 1 } },
+                        },
+                    },
+                },
+            },
+        });
+        expect(r1.m2).toHaveLength(0);
+
+        // m1 with empty m2 list
+        await db.m1.create({
+            data: {
+                id: '2',
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        every: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        every: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+
+    it('_count filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: [
+                        {
+                            value: 1,
+                            m3: {
+                                create: {
+                                    value: 1,
+                                },
+                            },
+                        },
+                        {
+                            value: 2,
+                            deleted: true,
+                            m3: {
+                                create: {
+                                    value: 2,
+                                    deleted: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+
+        await expect(db.m1.findFirst({ include: { _count: true } })).resolves.toMatchObject({ _count: { m2: 1 } });
+        await expect(db.m1.findFirst({ include: { _count: { select: { m2: true } } } })).resolves.toMatchObject({
+            _count: { m2: 1 },
+        });
+        await expect(
+            db.m1.findFirst({ include: { _count: { select: { m2: { where: { value: { gt: 0 } } } } } } }),
+        ).resolves.toMatchObject({ _count: { m2: 1 } });
+        await expect(
+            db.m1.findFirst({ include: { _count: { select: { m2: { where: { value: { gt: 1 } } } } } } }),
+        ).resolves.toMatchObject({ _count: { m2: 0 } });
+
+        await expect(db.m1.findFirst({ include: { m2: { select: { _count: true } } } })).resolves.toMatchObject({
+            m2: [{ _count: { m3: 1 } }],
+        });
+        await expect(
+            db.m1.findFirst({ include: { m2: { select: { _count: { select: { m3: true } } } } } }),
+        ).resolves.toMatchObject({ m2: [{ _count: { m3: 1 } }] });
+        await expect(
+            db.m1.findFirst({
+                include: { m2: { select: { _count: { select: { m3: { where: { value: { gt: 1 } } } } } } } },
+            }),
+        ).resolves.toMatchObject({ m2: [{ _count: { m3: 0 } }] });
+    });
+});
+
+// TODO: field-level policy support
+describe.skip('Relation one-to-many filter with field-level rules', () => {
+    const model = `
+    model M1 {
+        id String @id @default(uuid())
+        m2 M2[]
+    
+        @@allow('all', true)
+    }
+    
+    model M2 {
+        id String @id @default(uuid())
+        value Int @allow('read', !deleted)
+        deleted Boolean @default(false)
+        m1 M1 @relation(fields: [m1Id], references:[id])
+        m1Id String
+        m3 M3[]
+    
+        @@allow('read', true)
+        @@allow('create', true)
+    }
+
+    model M3 {
+        id String @id @default(uuid())
+        value Int @deny('read', deleted)
+        deleted Boolean @default(false)
+        m2 M2 @relation(fields: [m2Id], references:[id])
+        m2Id String
+
+        @@allow('read', true)
+        @@allow('create', true)
+    }
+    `;
+
+    it('some filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: [
+                        {
+                            id: '2-1',
+                            value: 1,
+                            m3: {
+                                create: {
+                                    id: '3-1',
+                                    value: 1,
+                                },
+                            },
+                        },
+                        {
+                            id: '2-2',
+                            value: 2,
+                            deleted: true,
+                            m3: {
+                                create: {
+                                    id: '3-2',
+                                    value: 2,
+                                    deleted: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        some: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        some: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        some: { id: '2-2' },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // include clause
+
+        const r = await db.m1.findFirst({
+            where: { id: '1' },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            some: {},
+                        },
+                    },
+                },
+            },
+        });
+        expect(r.m2).toHaveLength(2);
+
+        let r1 = await db.m1.findFirst({
+            where: {
+                id: '1',
+            },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            some: { value: { gt: 1 } },
+                        },
+                    },
+                },
+            },
+        });
+        expect(r1.m2).toHaveLength(0);
+
+        r1 = await db.m1.findFirst({
+            where: {
+                id: '1',
+            },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            some: { id: { equals: '3-2' } },
+                        },
+                    },
+                },
+            },
+        });
+        expect(r1.m2).toHaveLength(1);
+    });
+
+    it('none filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: [
+                        {
+                            id: '2-1',
+                            value: 1,
+                            m3: {
+                                create: {
+                                    id: '3-1',
+                                    value: 1,
+                                },
+                            },
+                        },
+                        {
+                            id: '2-2',
+                            value: 2,
+                            deleted: true,
+                            m3: {
+                                create: {
+                                    id: '3-2',
+                                    value: 2,
+                                    deleted: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        none: {},
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        none: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        none: { id: '2-1' },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // include clause
+
+        let r = await db.m1.findFirst({
+            where: {
+                id: '1',
+            },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            none: { value: { gt: 1 } },
+                        },
+                    },
+                },
+            },
+        });
+        expect(r.m2).toHaveLength(2);
+
+        r = await db.m1.findFirst({
+            where: {
+                id: '1',
+            },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            none: { id: { equals: '3-2' } },
+                        },
+                    },
+                },
+            },
+        });
+        expect(r.m2).toHaveLength(1);
+    });
+
+    it('every filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: [
+                        {
+                            id: '2-1',
+                            value: 1,
+                            m3: {
+                                create: {
+                                    id: '3-1',
+                                    value: 1,
+                                },
+                            },
+                        },
+                        {
+                            id: '2-2',
+                            value: 2,
+                            deleted: true,
+                            m3: {
+                                create: {
+                                    id: '3-2',
+                                    value: 2,
+                                    deleted: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        every: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        every: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        every: { id: { contains: '2' } },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // include clause
+
+        const r = await db.m1.findFirst({
+            where: { id: '1' },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            every: {},
+                        },
+                    },
+                },
+            },
+        });
+        expect(r.m2).toHaveLength(2);
+
+        let r1 = await db.m1.findFirst({
+            where: {
+                id: '1',
+            },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            every: { value: { gt: 1 } },
+                        },
+                    },
+                },
+            },
+        });
+        expect(r1.m2).toHaveLength(1);
+
+        r1 = await db.m1.findFirst({
+            where: {
+                id: '1',
+            },
+            include: {
+                m2: {
+                    where: {
+                        m3: {
+                            every: { id: { contains: '3' } },
+                        },
+                    },
+                },
+            },
+        });
+        expect(r1.m2).toHaveLength(2);
+    });
+});
+
+// TODO: field-level policy support
+describe.skip('Relation one-to-many filter with field-level override rules', () => {
+    const model = `
+    model M1 {
+        id String @id @default(uuid())
+        m2 M2[]
+    
+        @@allow('all', true)
+    }
+    
+    model M2 {
+        id String @id @default(uuid()) @allow('read', true, true)
+        value Int @allow('read', !deleted)
+        deleted Boolean @default(false)
+        m1 M1 @relation(fields: [m1Id], references:[id])
+        m1Id String
+    
+        @@allow('read', !deleted)
+        @@allow('create', true)
+    }
+    `;
+
+    it('some filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: [
+                        {
+                            id: '2-1',
+                            value: 1,
+                        },
+                        {
+                            id: '2-2',
+                            value: 2,
+                            deleted: true,
+                        },
+                    ],
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        some: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        some: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        some: { id: '2-2' },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+
+    it('none filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: [
+                        {
+                            id: '2-1',
+                            value: 1,
+                        },
+                        {
+                            id: '2-2',
+                            value: 2,
+                            deleted: true,
+                        },
+                    ],
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        none: {},
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        none: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        none: { id: '2-1' },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+    });
+
+    it('every filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: [
+                        {
+                            id: '2-1',
+                            value: 1,
+                        },
+                        {
+                            id: '2-2',
+                            value: 2,
+                            deleted: true,
+                        },
+                    ],
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        every: {},
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        every: { value: { gt: 1 } },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        every: { id: { contains: '2' } },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+});

--- a/packages/runtime/test/policy/migrated/relation-one-to-one-filter.test.ts
+++ b/packages/runtime/test/policy/migrated/relation-one-to-one-filter.test.ts
@@ -1,0 +1,1096 @@
+import { describe, expect, it } from 'vitest';
+import { createPolicyTestClient } from '../utils';
+
+describe('Relation one-to-one filter', () => {
+    const model = `
+    model M1 {
+        id String @id @default(uuid())
+        m2 M2?
+    
+        @@allow('all', true)
+    }
+    
+    model M2 {
+        id String @id @default(uuid())
+        value Int
+        deleted Boolean @default(false)
+        m1 M1 @relation(fields: [m1Id], references:[id])
+        m1Id String @unique
+        m3 M3?
+    
+        @@allow('read', !deleted)
+        @@allow('create', true)
+    }
+
+    model M3 {
+        id String @id @default(uuid())
+        value Int
+        deleted Boolean @default(false)
+        m2 M2 @relation(fields: [m2Id], references:[id])
+        m2Id String @unique
+
+        @@allow('read', !deleted)
+        @@allow('create', true)
+    }
+    `;
+
+    it('is filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: {
+                        value: 1,
+                        m3: {
+                            create: {
+                                value: 1,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        is: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with m2
+        await db.m1.create({
+            data: {
+                id: '2',
+                m2: {
+                    create: {
+                        value: 1,
+                        deleted: true,
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        is: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '3',
+                m2: {
+                    create: {
+                        value: 1,
+                        m3: {
+                            create: {
+                                value: 1,
+                                deleted: true,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        is: {
+                            m3: { value: 1 },
+                        },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // m1 with null m2
+        await db.m1.create({
+            data: {
+                id: '4',
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '4',
+                    m2: {
+                        is: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+    });
+
+    it('isNot filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: {
+                        value: 1,
+                        m3: {
+                            create: {
+                                value: 1,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        isNot: { value: 0 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        isNot: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // m1 with m2
+        await db.m1.create({
+            data: {
+                id: '2',
+                m2: {
+                    create: {
+                        value: 1,
+                        deleted: true,
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        isNot: { value: 0 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        isNot: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '3',
+                m2: {
+                    create: {
+                        value: 1,
+                        m3: {
+                            create: {
+                                value: 1,
+                                deleted: true,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        isNot: {
+                            m3: {
+                                isNot: { value: 0 },
+                            },
+                        },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        isNot: {
+                            m3: {
+                                isNot: { value: 1 },
+                            },
+                        },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // m1 with null m2
+        await db.m1.create({
+            data: {
+                id: '4',
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '4',
+                    m2: {
+                        isNot: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+
+    it('direct object filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: {
+                        value: 1,
+                        m3: {
+                            create: {
+                                value: 1,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        value: 1,
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with m2
+        await db.m1.create({
+            data: {
+                id: '2',
+                m2: {
+                    create: {
+                        value: 1,
+                        deleted: true,
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        value: 1,
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '3',
+                m2: {
+                    create: {
+                        value: 1,
+                        m3: {
+                            create: {
+                                value: 1,
+                                deleted: true,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        m3: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // m1 with null m2
+        await db.m1.create({
+            data: {
+                id: '4',
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '4',
+                    m2: {
+                        value: 1,
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+    });
+});
+
+// TODO: field-level policy support
+describe.skip('Relation one-to-one filter with field-level rules', () => {
+    const model = `
+    model M1 {
+        id String @id @default(uuid())
+        m2 M2?
+    
+        @@allow('all', true)
+    }
+    
+    model M2 {
+        id String @id @default(uuid())
+        value Int @allow('read', !deleted)
+        deleted Boolean @default(false)
+        m1 M1 @relation(fields: [m1Id], references:[id])
+        m1Id String @unique
+        m3 M3?
+    
+        @@allow('read', true)
+        @@allow('create', true)
+    }
+
+    model M3 {
+        id String @id @default(uuid())
+        value Int @allow('read', !deleted)
+        deleted Boolean @default(false)
+        m2 M2 @relation(fields: [m2Id], references:[id])
+        m2Id String @unique
+
+        @@allow('read', true)
+        @@allow('create', true)
+    }
+    `;
+
+    it('is filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: {
+                        id: '1',
+                        value: 1,
+                        m3: {
+                            create: {
+                                id: '1',
+                                value: 1,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        is: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with m2
+        await db.m1.create({
+            data: {
+                id: '2',
+                m2: {
+                    create: {
+                        id: '2',
+                        value: 1,
+                        deleted: true,
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        is: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        is: { id: '2' },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '3',
+                m2: {
+                    create: {
+                        id: '3',
+                        value: 1,
+                        m3: {
+                            create: {
+                                id: '3',
+                                value: 1,
+                                deleted: true,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        is: {
+                            m3: { value: 1 },
+                        },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        is: {
+                            m3: { id: '3' },
+                        },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+
+    it('isNot filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: {
+                        id: '1',
+                        value: 1,
+                        m3: {
+                            create: {
+                                id: '1',
+                                value: 1,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        isNot: { value: 0 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        isNot: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // m1 with m2
+        await db.m1.create({
+            data: {
+                id: '2',
+                m2: {
+                    create: {
+                        id: '2',
+                        value: 1,
+                        deleted: true,
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        isNot: { value: 0 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        isNot: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        isNot: { id: '2' },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+    });
+
+    it('direct object filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: {
+                        id: '1',
+                        value: 1,
+                        m3: {
+                            create: {
+                                value: 1,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        value: 1,
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with m2
+        await db.m1.create({
+            data: {
+                id: '2',
+                m2: {
+                    create: {
+                        id: '2',
+                        value: 1,
+                        deleted: true,
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        value: 1,
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        id: '2',
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '3',
+                m2: {
+                    create: {
+                        id: '3',
+                        value: 1,
+                        m3: {
+                            create: {
+                                id: '3',
+                                value: 1,
+                                deleted: true,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        m3: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        m3: { id: '3' },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+});
+
+// TODO: field-level policy support
+describe.skip('Relation one-to-one filter with field-level override rules', () => {
+    const model = `
+    model M1 {
+        id String @id @default(uuid())
+        m2 M2?
+    
+        @@allow('all', true)
+    }
+    
+    model M2 {
+        id String @id @default(uuid()) @allow('read', true, true)
+        value Int
+        deleted Boolean @default(false)
+        m1 M1 @relation(fields: [m1Id], references:[id])
+        m1Id String @unique
+        m3 M3?
+    
+        @@allow('read', !deleted)
+        @@allow('create', true)
+    }
+
+    model M3 {
+        id String @id @default(uuid()) @allow('read', true, true)
+        value Int
+        deleted Boolean @default(false)
+        m2 M2 @relation(fields: [m2Id], references:[id])
+        m2Id String @unique
+
+        @@allow('read', !deleted)
+        @@allow('create', true)
+    }
+    `;
+
+    it('is filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: {
+                        id: '1',
+                        value: 1,
+                        m3: {
+                            create: {
+                                id: '1',
+                                value: 1,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        is: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with m2
+        await db.m1.create({
+            data: {
+                id: '2',
+                m2: {
+                    create: {
+                        id: '2',
+                        value: 1,
+                        deleted: true,
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        is: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        is: { id: '2' },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '3',
+                m2: {
+                    create: {
+                        id: '3',
+                        value: 1,
+                        m3: {
+                            create: {
+                                id: '3',
+                                value: 1,
+                                deleted: true,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        is: {
+                            m3: { value: 1 },
+                        },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        is: {
+                            m3: { id: '3' },
+                        },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+
+    it('isNot filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: {
+                        id: '1',
+                        value: 1,
+                        m3: {
+                            create: {
+                                id: '1',
+                                value: 1,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        isNot: { value: 0 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        isNot: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        // m1 with m2
+        await db.m1.create({
+            data: {
+                id: '2',
+                m2: {
+                    create: {
+                        id: '2',
+                        value: 1,
+                        deleted: true,
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        isNot: { value: 0 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        isNot: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        isNot: { id: '2' },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+    });
+
+    it('direct object filter', async () => {
+        const db = await createPolicyTestClient(model);
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '1',
+                m2: {
+                    create: {
+                        id: '1',
+                        value: 1,
+                        m3: {
+                            create: {
+                                value: 1,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '1',
+                    m2: {
+                        value: 1,
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with m2
+        await db.m1.create({
+            data: {
+                id: '2',
+                m2: {
+                    create: {
+                        id: '2',
+                        value: 1,
+                        deleted: true,
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        value: 1,
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '2',
+                    m2: {
+                        id: '2',
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+
+        // m1 with m2 and m3
+        await db.m1.create({
+            data: {
+                id: '3',
+                m2: {
+                    create: {
+                        id: '3',
+                        value: 1,
+                        m3: {
+                            create: {
+                                id: '3',
+                                value: 1,
+                                deleted: true,
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        m3: { value: 1 },
+                    },
+                },
+            }),
+        ).toResolveFalsy();
+
+        await expect(
+            db.m1.findFirst({
+                where: {
+                    id: '3',
+                    m2: {
+                        m3: { id: '3' },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+});

--- a/packages/runtime/test/policy/migrated/self-relation.test.ts
+++ b/packages/runtime/test/policy/migrated/self-relation.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'vitest';
+import { createPolicyTestClient } from '../utils';
+
+describe('Policy self relations tests', () => {
+    it('one-to-one', async () => {
+        const db = await createPolicyTestClient(
+            `
+            model User {
+                id          Int     @id @default(autoincrement())
+                value       Int
+                successorId Int?    @unique
+                successor   User?   @relation("BlogOwnerHistory", fields: [successorId], references: [id])
+                predecessor User?   @relation("BlogOwnerHistory")
+
+                @@allow('create', value > 0)
+                @@allow('read', true)
+            }
+        `,
+            { usePrismaPush: true },
+        );
+
+        // create denied
+        await expect(
+            db.user.create({
+                data: {
+                    value: 0,
+                },
+            }),
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.user.create({
+                data: {
+                    value: 1,
+                    successor: {
+                        create: {
+                            value: 0,
+                        },
+                    },
+                },
+            }),
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.user.create({
+                data: {
+                    value: 1,
+                    successor: {
+                        create: {
+                            value: 1,
+                        },
+                    },
+                    predecessor: {
+                        create: {
+                            value: 0,
+                        },
+                    },
+                },
+            }),
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.user.create({
+                data: {
+                    value: 1,
+                    successor: {
+                        create: {
+                            value: 1,
+                        },
+                    },
+                    predecessor: {
+                        create: {
+                            value: 1,
+                        },
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+
+    it('one-to-many', async () => {
+        const db = await createPolicyTestClient(
+            `
+            model User {
+                id        Int     @id @default(autoincrement())
+                value     Int
+                teacherId Int?
+                teacher   User?   @relation("TeacherStudents", fields: [teacherId], references: [id])
+                students  User[]  @relation("TeacherStudents")
+
+                @@allow('create', value > 0)
+                @@allow('read', true)
+            }
+        `,
+            { usePrismaPush: true },
+        );
+
+        // create denied
+        await expect(
+            db.user.create({
+                data: {
+                    value: 0,
+                },
+            }),
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.user.create({
+                data: {
+                    value: 1,
+                    teacher: {
+                        create: { value: 0 },
+                    },
+                },
+            }),
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.user.create({
+                data: {
+                    value: 1,
+                    teacher: {
+                        create: { value: 1 },
+                    },
+                    students: {
+                        create: [{ value: 0 }, { value: 1 }],
+                    },
+                },
+            }),
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.user.create({
+                data: {
+                    value: 1,
+                    teacher: {
+                        create: { value: 1 },
+                    },
+                    students: {
+                        create: [{ value: 1 }, { value: 2 }],
+                    },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+
+    it('many-to-many', async () => {
+        const db = await createPolicyTestClient(
+            `
+            model User {
+                id         Int     @id @default(autoincrement())
+                value      Int
+                followedBy User[]  @relation("UserFollows")
+                following  User[]  @relation("UserFollows")
+
+                @@allow('create', value > 0)
+                @@allow('read', true)                
+            }
+        `,
+            { usePrismaPush: true },
+        );
+
+        // create denied
+        await expect(
+            db.user.create({
+                data: {
+                    value: 0,
+                },
+            }),
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.user.create({
+                data: {
+                    value: 1,
+                    followedBy: { create: { value: 0 } },
+                },
+            }),
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.user.create({
+                data: {
+                    value: 1,
+                    followedBy: { create: { value: 1 } },
+                    following: { create: [{ value: 0 }, { value: 1 }] },
+                },
+            }),
+        ).toBeRejectedByPolicy();
+
+        await expect(
+            db.user.create({
+                data: {
+                    value: 1,
+                    followedBy: { create: { value: 1 } },
+                    following: { create: [{ value: 1 }, { value: 2 }] },
+                },
+            }),
+        ).toResolveTruthy();
+    });
+});

--- a/packages/runtime/test/policy/migrated/self-relation.test.ts
+++ b/packages/runtime/test/policy/migrated/self-relation.test.ts
@@ -12,7 +12,7 @@ describe('Policy self relations tests', () => {
                 successor   User?   @relation("BlogOwnerHistory", fields: [successorId], references: [id])
                 predecessor User?   @relation("BlogOwnerHistory")
 
-                @@allow('create', value > 0)
+                @@allow('create,update', value > 0)
                 @@allow('read', true)
             }
         `,
@@ -88,7 +88,7 @@ describe('Policy self relations tests', () => {
                 teacher   User?   @relation("TeacherStudents", fields: [teacherId], references: [id])
                 students  User[]  @relation("TeacherStudents")
 
-                @@allow('create', value > 0)
+                @@allow('create,update', value > 0)
                 @@allow('read', true)
             }
         `,
@@ -153,7 +153,7 @@ describe('Policy self relations tests', () => {
                 followedBy User[]  @relation("UserFollows")
                 following  User[]  @relation("UserFollows")
 
-                @@allow('create', value > 0)
+                @@allow('create,update', value > 0)
                 @@allow('read', true)                
             }
         `,

--- a/packages/testtools/src/schema.ts
+++ b/packages/testtools/src/schema.ts
@@ -41,7 +41,7 @@ export async function generateTsSchema(
     const noPrelude = schemaText.includes('datasource ');
     fs.writeFileSync(zmodelPath, `${noPrelude ? '' : makePrelude(provider, dbUrl)}\n\n${schemaText}`);
 
-    const pluginModelFiles = glob.sync(path.resolve(__dirname, '../../runtime/src/plugins/**/plugin.zmodel'));
+    const pluginModelFiles = getPluginModules();
     const result = await loadDocument(zmodelPath, pluginModelFiles);
     if (!result.success) {
         throw new Error(`Failed to load schema from ${zmodelPath}: ${result.errors}`);
@@ -59,7 +59,11 @@ export async function generateTsSchema(
     }
 
     // compile the generated TS schema
-    return compileAndLoad(workDir);
+    return { ...(await compileAndLoad(workDir)), model: result.model };
+}
+
+export function getPluginModules() {
+    return glob.sync(path.resolve(__dirname, '../../runtime/src/plugins/**/plugin.zmodel'));
 }
 
 async function compileAndLoad(workDir: string) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Policies now enforce many-to-many relations across create/read/update/delete.
  - Exposed a new zip utility via common helpers.

- Improvements
  - Relation filters (some/none/every) and nested _count handling improved.
  - Boolean literal handling in policy expressions improved.
  - Better support for self-referential relations and many-to-many metadata validation.

- Tests
  - Added integration tests covering many-to-many, one-to-many, one-to-one, and self-relation policy scenarios.

- Chores
  - Updated test tooling and schema loading helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->