### PR TITLE
fix: prisma schema generation issue with `default()` using `auth()`

### DIFF
--- a/packages/sdk/src/prisma/prisma-schema-generator.ts
+++ b/packages/sdk/src/prisma/prisma-schema-generator.ts
@@ -18,10 +18,8 @@ import {
     InvocationExpr,
     isArrayExpr,
     isDataModel,
-    isExpression,
     isInvocationExpr,
     isLiteralExpr,
-    isModel,
     isNullExpr,
     isReferenceExpr,
     isStringLiteral,
@@ -271,12 +269,7 @@ export class PrismaSchemaGenerator {
             return false;
         }
 
-        return AstUtils.streamAst(expr).some((node) => isExpression(node) && isAuthInvocation(node));
-    }
-
-    private isFromPlugin(node: AstNode | undefined) {
-        const model = AstUtils.getContainerOfType(node, isModel);
-        return !!model && !!model.$document && model.$document.uri.path.endsWith('plugin.zmodel');
+        return AstUtils.streamAst(expr).some(isAuthInvocation);
     }
 
     private isInheritedFromDelegate(field: DataField, contextModel: DataModel) {

--- a/packages/testtools/src/project.ts
+++ b/packages/testtools/src/project.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import tmp from 'tmp';
 
-export function createTestProject() {
+export function createTestProject(zmodelContent?: string) {
     const { name: workDir } = tmp.dirSync({ unsafeCleanup: true });
 
     fs.mkdirSync(path.join(workDir, 'node_modules'));
@@ -62,6 +62,10 @@ export function createTestProject() {
             4,
         ),
     );
+
+    if (zmodelContent) {
+        fs.writeFileSync(path.join(workDir, 'schema.zmodel'), zmodelContent);
+    }
 
     return workDir;
 }

--- a/tests/regression/test/issue-204/regression.test.ts
+++ b/tests/regression/test/issue-204/regression.test.ts
@@ -1,11 +1,9 @@
-import { describe, it } from 'vitest';
+import { it } from 'vitest';
 import { type Configuration, ShirtColor } from './models';
 
-describe('Issue 204 regression tests', () => {
-    it('tests issue 204', () => {
-        const config: Configuration = { teamColors: [ShirtColor.Black, ShirtColor.Blue] };
-        console.log(config.teamColors?.[0]);
-        const config1: Configuration = {};
-        console.log(config1);
-    });
+it('tests issue 204', () => {
+    const config: Configuration = { teamColors: [ShirtColor.Black, ShirtColor.Blue] };
+    console.log(config.teamColors?.[0]);
+    const config1: Configuration = {};
+    console.log(config1);
 });

--- a/tests/regression/test/issue-274/regression.test.ts
+++ b/tests/regression/test/issue-274/regression.test.ts
@@ -1,0 +1,29 @@
+import { createTestProject } from '@zenstackhq/testtools';
+import { execSync } from 'child_process';
+import { it } from 'vitest';
+
+it('tests issue 274', async () => {
+    const dir = await createTestProject(`
+
+datasource db {
+  provider = 'sqlite'
+  url      = "file:./test.db"
+}
+
+model Comment {  
+  id            String       @id
+  author        User?     @relation(fields: [authorId], references: [id])
+  authorId      String?   @default(auth().id) 
+}
+
+model User {
+    id            String       @id
+    email         String
+    comments      Comment[]    
+}
+`);
+
+    process.chdir(dir);
+
+    execSync('node node_modules/@zenstackhq/cli/dist/index.js migrate dev --name init');
+});

--- a/tests/regression/test/issue-274/regression.test.ts
+++ b/tests/regression/test/issue-274/regression.test.ts
@@ -23,7 +23,5 @@ model User {
 }
 `);
 
-    process.chdir(dir);
-
-    execSync('node node_modules/@zenstackhq/cli/dist/index.js migrate dev --name init');
+    execSync('node node_modules/@zenstackhq/cli/dist/index.js migrate dev --name init', { cwd: dir });
 });


### PR DESCRIPTION
fixes #274


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Test project utility accepts optional inline schema content for quicker setup.
- Bug Fixes
  - Improved handling of auth-based default values to ensure accurate schema generation and prevent unintended defaults.
- Tests
  - Added a regression test covering auth-derived default values in relations (issue 274).
  - Simplified an existing regression test structure for clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->