### PR TITLE
fix: don't inherit inherited map attribute

### DIFF
--- a/packages/sdk/src/prisma/prisma-schema-generator.ts
+++ b/packages/sdk/src/prisma/prisma-schema-generator.ts
@@ -171,7 +171,9 @@ export class PrismaSchemaGenerator {
         }
 
         const allAttributes = getAllAttributes(decl);
-        for (const attr of allAttributes.filter((attr) => this.isPrismaAttribute(attr))) {
+        for (const attr of allAttributes.filter(
+            (attr) => this.isPrismaAttribute(attr) && !this.isInheritedMapAttribute(attr, decl),
+        )) {
             this.generateContainerAttribute(model, attr);
         }
 
@@ -183,6 +185,15 @@ export class PrismaSchemaGenerator {
 
         // generate reverse relation fields on concrete models
         this.generateDelegateRelationForConcrete(model, decl);
+    }
+
+    private isInheritedMapAttribute(attr: DataModelAttribute, contextModel: DataModel) {
+        if (attr.$container === contextModel) {
+            return false;
+        }
+
+        const attrName = attr.decl.ref?.name ?? attr.decl.$refText;
+        return attrName === '@@map';
     }
 
     private isPrismaAttribute(attr: DataModelAttribute | DataFieldAttribute) {


### PR DESCRIPTION
Resolves #291 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Prisma schema generation to ignore inherited mapping attributes from base models, preventing unintended propagation of @@map. This eliminates duplicate or invalid mappings in generated schemas, reducing validation and migration errors and producing more predictable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->