### PR TITLE
fix: skip generators for `migrate reset`

### DIFF
--- a/packages/cli/src/actions/migrate.ts
+++ b/packages/cli/src/actions/migrate.ts
@@ -82,9 +82,12 @@ async function runDev(prismaSchemaFile: string, options: DevOptions) {
 
 async function runReset(prismaSchemaFile: string, options: ResetOptions) {
     try {
-        const cmd = ['prisma migrate reset', ` --schema "${prismaSchemaFile}"`, options.force ? ' --force' : ''].join(
-            '',
-        );
+        const cmd = [
+            'prisma migrate reset',
+            ` --schema "${prismaSchemaFile}"`,
+            ' --skip-generate',
+            options.force ? ' --force' : ''
+        ].join('');
 
         await execPackage(cmd);
     } catch (err) {


### PR DESCRIPTION
An errant `prisma` folder containing the Prisma client was being generated when running `zen migrate reset`.

This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated the reset command to skip generation by default while preserving existing force flag behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->