### PR TITLE
Expose internal API handler and server adapter types to support custom handler and adapter implementations

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -39,6 +39,16 @@
                 "default": "./dist/api.cjs"
             }
         },
+        "./common": {
+            "import": {
+                "types": "./dist/common.d.ts",
+                "default": "./dist/common.js"
+            },
+            "require": {
+                "types": "./dist/common.d.cts",
+                "default": "./dist/common.cjs"
+            }
+        },
         "./express": {
             "import": {
                 "types": "./dist/express.d.ts",
@@ -117,6 +127,16 @@
             "require": {
                 "types": "./dist/tanstack-start.d.cts",
                 "default": "./dist/tanstack-start.cjs"
+            }
+        },
+        "./types": {
+            "import": {
+                "types": "./dist/types.d.ts",
+                "default": "./dist/types.js"
+            },
+            "require": {
+                "types": "./dist/types.d.cts",
+                "default": "./dist/types.cjs"
             }
         }
     },

--- a/packages/server/src/api/index.ts
+++ b/packages/server/src/api/index.ts
@@ -1,2 +1,3 @@
 export { RestApiHandler, type RestApiHandlerOptions } from './rest';
 export { RPCApiHandler, type RPCApiHandlerOptions } from './rpc';
+export * from './utils';

--- a/packages/server/src/api/rpc/index.ts
+++ b/packages/server/src/api/rpc/index.ts
@@ -27,7 +27,7 @@ export type RPCApiHandlerOptions<Schema extends SchemaDef> = {
  * RPC style API request handler that mirrors the ZenStackClient API
  */
 export class RPCApiHandler<Schema extends SchemaDef> implements ApiHandler<Schema> {
-    constructor(private readonly options: RPCApiHandlerOptions<Schema>) {}
+    constructor(protected readonly options: RPCApiHandlerOptions<Schema>) {}
 
     get schema(): Schema {
         return this.options.schema;
@@ -163,11 +163,11 @@ export class RPCApiHandler<Schema extends SchemaDef> implements ApiHandler<Schem
         }
     }
 
-    private isValidModel(client: ClientContract<Schema>, model: string) {
+    protected isValidModel(client: ClientContract<Schema>, model: string) {
         return Object.keys(client.$schema.models).some((m) => lowerCaseFirst(m) === lowerCaseFirst(model));
     }
 
-    private makeBadInputErrorResponse(message: string) {
+    protected makeBadInputErrorResponse(message: string) {
         const resp = {
             status: 400,
             body: { error: { message } },
@@ -176,7 +176,7 @@ export class RPCApiHandler<Schema extends SchemaDef> implements ApiHandler<Schem
         return resp;
     }
 
-    private makeGenericErrorResponse(err: unknown) {
+    protected makeGenericErrorResponse(err: unknown) {
         const resp = {
             status: 500,
             body: { error: { message: err instanceof Error ? err.message : 'unknown error' } },
@@ -189,7 +189,7 @@ export class RPCApiHandler<Schema extends SchemaDef> implements ApiHandler<Schem
         return resp;
     }
 
-    private makeORMErrorResponse(err: ORMError) {
+    protected makeORMErrorResponse(err: ORMError) {
         let status = 400;
         const error: any = { message: err.message, reason: err.reason };
 
@@ -220,7 +220,7 @@ export class RPCApiHandler<Schema extends SchemaDef> implements ApiHandler<Schem
         return resp;
     }
 
-    private async processRequestPayload(args: any) {
+    protected async processRequestPayload(args: any) {
         const { meta, ...rest } = args;
         if (meta?.serialization) {
             try {
@@ -233,7 +233,7 @@ export class RPCApiHandler<Schema extends SchemaDef> implements ApiHandler<Schem
         return { result: args, error: undefined };
     }
 
-    private unmarshalQ(value: string, meta: string | undefined) {
+    protected unmarshalQ(value: string, meta: string | undefined) {
         let parsedValue: any;
         try {
             parsedValue = JSON.parse(value);

--- a/packages/server/test/adapter/custom.test.ts
+++ b/packages/server/test/adapter/custom.test.ts
@@ -1,0 +1,119 @@
+import type { ClientContract } from '@zenstackhq/orm';
+import type { SchemaDef } from '@zenstackhq/orm/schema';
+import { describe, expect, it, vi } from 'vitest';
+import { logInternalError, type CommonAdapterOptions } from '../../src/adapter/common';
+import { type ApiHandler, type RequestContext, type Response } from '../../src/types';
+
+type AdapterRequest<Schema extends SchemaDef> = {
+    method: string;
+    path: string;
+    query?: Record<string, string | string[]>;
+    body?: unknown;
+    client: ClientContract<Schema>;
+};
+
+class RecordingHandler implements ApiHandler<SchemaDef> {
+    constructor(
+        protected readonly schemaDef: SchemaDef,
+        protected readonly response: Response,
+        protected readonly logger?: (...args: any[]) => void,
+    ) {}
+
+    readonly contexts: Array<RequestContext<SchemaDef>> = [];
+
+    get schema(): SchemaDef {
+        return this.schemaDef;
+    }
+
+    get log() {
+        return this.logger;
+    }
+
+    async handleRequest(context: RequestContext<SchemaDef>): Promise<Response> {
+        this.contexts.push(context);
+        return this.response;
+    }
+}
+
+class ThrowingHandler implements ApiHandler<SchemaDef> {
+    constructor(protected readonly schemaDef: SchemaDef, protected readonly logger: (...args: any[]) => void) {}
+
+    get schema(): SchemaDef {
+        return this.schemaDef;
+    }
+
+    get log() {
+        return this.logger;
+    }
+
+    async handleRequest(): Promise<Response> {
+        throw new Error('adapter failure');
+    }
+}
+
+function createCustomAdapter<Schema extends SchemaDef>(
+    options: CommonAdapterOptions<Schema>,
+): (request: AdapterRequest<Schema>) => Promise<Response> {
+    return async (request) => {
+        const context: RequestContext<Schema> = {
+            client: request.client,
+            method: request.method,
+            path: request.path,
+            query: request.query,
+            requestBody: request.body,
+        };
+
+        try {
+            return await options.apiHandler.handleRequest(context);
+        } catch (err) {
+            logInternalError(options.apiHandler.log, err);
+            throw err;
+        }
+    };
+}
+
+describe('Custom adapter test', () => {
+    const schema = {} as SchemaDef;
+    const client = { $schema: schema } as unknown as ClientContract<SchemaDef>;
+
+    it('delegates to api handler', async () => {
+        const response: Response = { status: 201, body: { ok: true } };
+        const handler = new RecordingHandler(schema, response);
+        const adapter = createCustomAdapter({ apiHandler: handler });
+
+        const result = await adapter({
+            method: 'get',
+            path: '/something',
+            query: { foo: 'bar' },
+            body: { value: 1 },
+            client,
+        });
+
+        expect(result).toEqual(response);
+        expect(handler.contexts).toHaveLength(1);
+        const captured = handler.contexts[0];
+        expect(captured.method).toBe('get');
+        expect(captured.path).toBe('/something');
+        expect(captured.query).toEqual({ foo: 'bar' });
+        expect(captured.requestBody).toEqual({ value: 1 });
+        expect(captured.client).toBe(client);
+    });
+
+    it('logs internal error when handler throws', async () => {
+        const logger = vi.fn();
+        const handler = new ThrowingHandler(schema, logger);
+        const adapter = createCustomAdapter({ apiHandler: handler });
+
+        await expect(
+            adapter({
+                method: 'post',
+                path: '/fail',
+                client,
+            }),
+        ).rejects.toThrow('adapter failure');
+        expect(logger).toHaveBeenCalledTimes(1);
+        const call = logger.mock.calls[0];
+        expect(call[0]).toBe('error');
+        expect(call[1]).toContain('An unhandled error occurred while processing the request: Error: adapter failure');
+    });
+});

--- a/packages/server/test/api/custom.test.ts
+++ b/packages/server/test/api/custom.test.ts
@@ -1,0 +1,62 @@
+import type { ClientContract } from '@zenstackhq/orm';
+import type { SchemaDef } from '@zenstackhq/orm/schema';
+import { Decimal } from 'decimal.js';
+import SuperJSON from 'superjson';
+import { describe, expect, it, vi } from 'vitest';
+import { log, registerCustomSerializers } from '../../src/api/utils';
+import { type ApiHandler, type LogConfig, type RequestContext, type Response } from '../../src/types';
+
+class CustomApiHandler implements ApiHandler<SchemaDef> {
+    protected readonly handled: Array<RequestContext<SchemaDef>> = [];
+
+    constructor(protected readonly schemaDef: SchemaDef, protected readonly logger: LogConfig) {}
+
+    get schema(): SchemaDef {
+        return this.schemaDef;
+    }
+
+    get log(): LogConfig {
+        return this.logger;
+    }
+
+    get contexts(): ReadonlyArray<RequestContext<SchemaDef>> {
+        return this.handled;
+    }
+
+    async handleRequest(context: RequestContext<SchemaDef>): Promise<Response> {
+        this.handled.push(context);
+        log(this.logger, 'info', () => `received ${context.method.toUpperCase()} ${context.path}`);
+        return { status: 202, body: { handled: true } };
+    }
+}
+
+describe('Custom API handler test', () => {
+    const schema = {} as SchemaDef;
+    const client = { $schema: schema } as unknown as ClientContract<SchemaDef>;
+
+    it('allows building custom handlers with logging helpers', async () => {
+        const logger = vi.fn();
+        const handler = new CustomApiHandler(schema, logger);
+
+        const response = await handler.handleRequest({
+            method: 'post',
+            path: '/custom',
+            query: { foo: 'bar' },
+            requestBody: { value: 1 },
+            client,
+        });
+
+        expect(response).toEqual({ status: 202, body: { handled: true } });
+        expect(handler.contexts).toHaveLength(1);
+        expect(handler.contexts[0].query).toEqual({ foo: 'bar' });
+        expect(logger).toHaveBeenCalledWith('info', 'received POST /custom', undefined);
+    });
+
+    it('provides serialization helpers for custom handlers', () => {
+        registerCustomSerializers();
+        const serialized = SuperJSON.serialize({ value: new Decimal('3.14159') });
+        const roundTripped = SuperJSON.deserialize(serialized) as { value: Decimal };
+        expect(Decimal.isDecimal(roundTripped.value)).toBe(true);
+        expect(roundTripped.value.toString()).toBe('3.14159');
+    });
+});

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
     entry: {
+        types: 'src/types.ts',
         api: 'src/api/index.ts',
+        common: 'src/adapter/common.ts',
         express: 'src/adapter/express/index.ts',
         next: 'src/adapter/next/index.ts',
         fastify: 'src/adapter/fastify/index.ts',


### PR DESCRIPTION
This change expands the server package to allow developers to build custom API handlers and server adapters. Several internal types, interfaces, and utilities are now exported so that custom implementations can follow the same patterns used by the built in REST and RPC handlers.

Key improvements include:
* New exports that allow extension of REST and RPC API handlers and the creation of additional handler types
* Additional exported types and interfaces that support custom server adapters
* Updated visibility of internal fields so custom handlers can override behavior such as query parsing or serialization
* New entry points in package.json to expose common api and types.

These updates make it possible to adjust handler behavior for specific needs, write entirely new handlers that behave consistently with existing ones, and implement new adapters for other server environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public exports for `./common` and `./types` modules, expanding the package's public API surface.
  * Enhanced extensibility of REST and RPC API handlers to support custom implementations through inheritance.

* **Tests**
  * Added test coverage for custom adapter and handler implementations demonstrating new extension capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->