### PR TITLE
Fix: BigInt validator coercing non-validator attributes (#423)

### DIFF
--- a/packages/orm/src/client/crud/validator/utils.ts
+++ b/packages/orm/src/client/crud/validator/utils.ts
@@ -125,19 +125,19 @@ export function addBigIntValidation(schema: z.ZodBigInt, attributes: AttributeAp
         if (val === undefined) {
             continue;
         }
-        const bigIntVal = BigInt(val);
+
         match(attr.name)
             .with('@gt', () => {
-                result = result.gt(bigIntVal);
+                result = result.gt(BigInt(val));
             })
             .with('@gte', () => {
-                result = result.gte(bigIntVal);
+                result = result.gte(BigInt(val));
             })
             .with('@lt', () => {
-                result = result.lt(bigIntVal);
+                result = result.lt(BigInt(val));
             })
             .with('@lte', () => {
-                result = result.lte(bigIntVal);
+                result = result.lte(BigInt(val));
             });
     }
     return result;

--- a/tests/regression/test/issue-423.test.ts
+++ b/tests/regression/test/issue-423.test.ts
@@ -1,0 +1,16 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+describe('Regression for issue #423', () => {
+    it('verifies non-validation attributes for BigInt does not fail', async () => {
+        const db = await createTestClient(
+            `
+model SampleBigInt {  
+  id            BigInt       @id @map("sample_id")
+  data          String
+}`,
+        );
+        await expect(db.SampleBigInt.create({ data: { data: "create", id: BigInt(1) } })).resolves.toMatchObject({ id: BigInt(1), data: "create" });
+        await expect(db.SampleBigInt.update({ data: { data: "update" }, where: { id: BigInt(1) } })).resolves.toMatchObject({ id: BigInt(1), data: "update" });
+    });
+});


### PR DESCRIPTION
Fixes #423 

The BigInt validator was attempting to coerce any value regardless if it was a validation attribute to a BigInt, this caused issues for things like `@map(column_name)` from working because it would throw an error attempting to coerce "column_name" into a BigInt value.

Changes:
* Stop coercing mapped attribute values into BigInt inside addBigIntValidation, limiting conversion to real validator attributes
* Add regression test proving @map-decorated BigInt fields create and update successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved BigInt field validation in CRUD operations.

* **Tests**
  * Added regression test for BigInt ID handling in create and update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->