### PR TITLE
fix(cli): require datasource url for running migration and db push commands

### DIFF
--- a/packages/cli/src/actions/action-utils.ts
+++ b/packages/cli/src/actions/action-utils.ts
@@ -135,3 +135,11 @@ function findUp<Multiple extends boolean = false>(
     }
     return findUp(names, up, multiple, result);
 }
+
+export async function requireDataSourceUrl(schemaFile: string) {
+    const zmodel = await loadSchemaDocument(schemaFile);
+    const dataSource = zmodel.declarations.find(isDataSource);
+    if (!dataSource?.fields.some((f) => f.name === 'url')) {
+        throw new CliError('The schema\'s "datasource" must have a "url" field to use this command.');
+    }
+}

--- a/packages/cli/src/actions/db.ts
+++ b/packages/cli/src/actions/db.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
 import { execPrisma } from '../utils/exec-utils';
-import { generateTempPrismaSchema, getSchemaFile, handleSubProcessError } from './action-utils';
+import { generateTempPrismaSchema, getSchemaFile, handleSubProcessError, requireDataSourceUrl } from './action-utils';
 
 type Options = {
     schema?: string;
@@ -20,8 +20,12 @@ export async function run(command: string, options: Options) {
 }
 
 async function runPush(options: Options) {
-    // generate a temp prisma schema file
     const schemaFile = getSchemaFile(options.schema);
+
+    // validate datasource url exists
+    await requireDataSourceUrl(schemaFile);
+
+    // generate a temp prisma schema file
     const prismaSchemaFile = await generateTempPrismaSchema(schemaFile);
 
     try {

--- a/packages/cli/src/actions/migrate.ts
+++ b/packages/cli/src/actions/migrate.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { CliError } from '../cli-error';
 import { execPrisma } from '../utils/exec-utils';
-import { generateTempPrismaSchema, getSchemaFile } from './action-utils';
+import { generateTempPrismaSchema, getSchemaFile, requireDataSourceUrl } from './action-utils';
 import { run as runSeed } from './seed';
 
 type CommonOptions = {
@@ -34,6 +34,10 @@ type ResolveOptions = CommonOptions & {
  */
 export async function run(command: string, options: CommonOptions) {
     const schemaFile = getSchemaFile(options.schema);
+
+    // validate datasource url exists
+    await requireDataSourceUrl(schemaFile);
+
     const prismaSchemaDir = options.migrations ? path.dirname(options.migrations) : undefined;
     const prismaSchemaFile = await generateTempPrismaSchema(schemaFile, prismaSchemaDir);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Database push and migrate operations now validate datasource configuration upfront before proceeding, preventing errors from missing or invalid datasource URLs during execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->