### PR TITLE
chore(cli): improve help text of migrate reset

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -94,6 +94,10 @@ function createProgram() {
         .addOption(new Option('--skip-seed', 'skip seeding the database after reset'))
         .addOption(noVersionCheckOption)
         .description('Reset your database and apply all migrations, all data will be lost')
+        .addHelpText(
+            'after',
+            '\nIf there is a seed script defined in package.json, it will be run after the reset. Use --skip-seed to skip it.',
+        )
         .action((options) => migrateAction('reset', options));
 
     migrateCommand


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated help text for the reset migrate subcommand to clarify that a seed script defined in package.json will be executed after migration by default, unless the --skip-seed option is specified.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->