### PR TITLE
fix(orm): correcting timezone for Date returned in nested queries

### DIFF
--- a/packages/orm/src/client/crud/dialects/postgresql.ts
+++ b/packages/orm/src/client/crud/dialects/postgresql.ts
@@ -106,7 +106,9 @@ export class PostgresCrudDialect<Schema extends SchemaDef> extends BaseCrudDiale
 
     private transformOutputDate(value: unknown) {
         if (typeof value === 'string') {
-            // force interpret as UTC
+            // PostgreSQL's jsonb_build_object serializes timestamptz as ISO 8601 strings
+            // in UTC but without the 'Z' suffix (e.g., "2023-01-01T12:00:00.123456").
+            // We add 'Z' to explicitly mark them as UTC for correct Date object creation.
             return new Date(value.endsWith('Z') ? value : `${value}Z`);
         } else if (value instanceof Date && this.options.fixPostgresTimezone !== false) {
             // SPECIAL NOTES:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of date/time strings for PostgreSQL so string timestamps without a timezone are treated as UTC, preventing local-time misinterpretation and ensuring consistent Date values across environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->