### PR TITLE
fix: elysia should utilize ctx.query vs. request.searchParams

### DIFF
--- a/packages/server/src/adapter/elysia/handler.ts
+++ b/packages/server/src/adapter/elysia/handler.ts
@@ -25,7 +25,7 @@ export interface ElysiaOptions<Schema extends SchemaDef> extends CommonAdapterOp
 export function createElysiaHandler<Schema extends SchemaDef>(options: ElysiaOptions<Schema>) {
     return async (app: Elysia) => {
         app.all('/*', async (ctx: ElysiaContext) => {
-            const { request, body, set } = ctx;
+            const { query, body, set, request } = ctx;
             const client = await options.getClient(ctx);
             if (!client) {
                 set.status = 500;
@@ -35,7 +35,6 @@ export function createElysiaHandler<Schema extends SchemaDef>(options: ElysiaOpt
             }
 
             const url = new URL(request.url);
-            const query = Object.fromEntries(url.searchParams);
             let path = url.pathname;
 
             if (options.basePath && path.startsWith(options.basePath)) {


### PR DESCRIPTION
* The standard way to access request query parameters is through ctx.query, not request.searchParams.
* request.searchParams can be utilized but generally elysia utilizes ctx.query, unfortunately, they are not synchronized but ctx.query is generally where you would derive additional fields vs. request.searchParams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal query parameter handling in the server adapter for better efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->