### PR TITLE
fix(server): app aliases are not allowed in server runtime

### DIFF
--- a/packages/server/src/adapter/nuxt/handler.ts
+++ b/packages/server/src/adapter/nuxt/handler.ts
@@ -1,12 +1,12 @@
 import type { ClientContract } from '@zenstackhq/orm';
 import type { SchemaDef } from '@zenstackhq/orm/schema';
 import {
-    H3Event,
     defineEventHandler,
     getQuery,
     getRouterParams,
     readBody,
     setResponseStatus,
+    type H3Event,
     type EventHandlerRequest,
 } from 'h3';
 import { logInternalError, type CommonAdapterOptions } from '../common';


### PR DESCRIPTION
This `PR` imports `setResponseStatus` directly from `h3`.

Importing from `nuxt/app` will fail in Nuxt 4.x because there are stronger separation of aliases between `client` and `server` runtimes

`nuxt/app` should NOT be used in server/ routes - it's meant for client-side and SSR rendering context only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal code organization and maintainability by consolidating imports and type usage.
  * No changes to public interfaces or runtime behavior; no user-facing impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->