### PR TITLE
fix(orm): more robust timezone adjustment for postgres

### DIFF
--- a/packages/orm/src/client/crud/dialects/postgresql.ts
+++ b/packages/orm/src/client/crud/dialects/postgresql.ts
@@ -109,7 +109,7 @@ export class PostgresCrudDialect<Schema extends SchemaDef> extends BaseCrudDiale
 
     private transformOutputDate(value: unknown) {
         if (typeof value === 'string') {
-            // PostgreSQL's jsonb_build_object serializes timestampt as ISO 8601 strings
+            // PostgreSQL's jsonb_build_object serializes timestamp as ISO 8601 strings
             // without timezone, (e.g., "2023-01-01T12:00:00.123456"). Since Date is always
             // stored as UTC `timestamp` type, we add 'Z' to explicitly mark them as UTC for
             // correct Date object creation.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL date handling: string dates are now validated before parsing, existing timezone offsets are preserved, and missing offsets are normalized so parsed dates reflect correct UTC timing. Non-date values and prior Date-handling behavior remain unchanged.

* **Chores**
  * No public API or exported signatures were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->