### PR TITLE
fix(zmodel): rejects delegate models with missing opposite relation

### DIFF
--- a/packages/language/src/validators/datamodel-validator.ts
+++ b/packages/language/src/validators/datamodel-validator.ts
@@ -250,7 +250,7 @@ export default class DataModelValidator implements AstValidator<DataModel> {
             return;
         }
 
-        if (this.isFieldInheritedFromDelegateModel(field)) {
+        if (this.isFieldInheritedFromDelegateModel(field, contextModel)) {
             // relation fields inherited from delegate model don't need opposite relation
             return;
         }
@@ -431,8 +431,8 @@ export default class DataModelValidator implements AstValidator<DataModel> {
     }
 
     // checks if the given field is inherited directly or indirectly from a delegate model
-    private isFieldInheritedFromDelegateModel(field: DataField) {
-        return isDelegateModel(field.$container);
+    private isFieldInheritedFromDelegateModel(field: DataField, contextModel: DataModel) {
+        return field.$container !== contextModel && isDelegateModel(field.$container);
     }
 
     private validateInherits(model: DataModel, accept: ValidationAcceptor) {

--- a/packages/language/test/delegate.test.ts
+++ b/packages/language/test/delegate.test.ts
@@ -114,4 +114,54 @@ describe('Delegate Tests', () => {
             'can only be applied once',
         );
     });
+
+    it('rejects relation missing the opposite side', async () => {
+        await loadSchemaWithError(
+            `
+        datasource db {
+            provider = 'sqlite'
+            url      = 'file:./dev.db'
+        }
+        
+        model A {
+            id Int @id @default(autoincrement())
+            b B @relation(fields: [bId], references: [id])
+            bId Int
+            type String
+            @@delegate(type)
+        }
+
+        model B {
+            id Int @id @default(autoincrement())
+        }
+        `,
+            'missing an opposite relation',
+        );
+
+        await loadSchema(
+            `
+        datasource db {
+            provider = 'sqlite'
+            url      = 'file:./dev.db'
+        }
+        
+        model A {
+            id Int @id @default(autoincrement())
+            b B @relation(fields: [bId], references: [id])
+            bId Int
+            type String
+            @@delegate(type)
+        }
+
+        model B {
+            id Int @id @default(autoincrement())
+            a A[]
+        }
+
+        model C extends A {
+            c String
+        }
+        `,
+        );
+    });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation logic for inherited fields from delegate models to correctly distinguish between inherited and locally-defined fields.

* **Tests**
  * Added test coverage for validating that delegate model relations properly declare opposite sides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->