### PR TITLE
fix(policy): reject access to undefined models

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -104,7 +104,7 @@
     - [x] Inject "on conflict do update"
     - [x] `check` function
     - [ ] Custom functions
-    - [ ] Accessing tables not in the schema
+    - [x] Accessing tables not in the schema
 - [x] Migration
 - [ ] Databases
     - [x] SQLite

--- a/tests/e2e/orm/policy/nonexistent-models.test.ts
+++ b/tests/e2e/orm/policy/nonexistent-models.test.ts
@@ -1,0 +1,59 @@
+import { createPolicyTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+describe('Policy tests for nonexistent models and fields', () => {
+    it('rejects access to nonexistent model', async () => {
+        const db = await createPolicyTestClient(
+            `
+            model Foo {
+                id String @id @default(cuid())
+                string String
+                @@allow('all', true)
+            }
+            `,
+        );
+        const dbRaw = db.$unuseAll();
+
+        // create a Bar table
+        await dbRaw.$executeRawUnsafe(
+            `CREATE TABLE "Bar" ("id" TEXT PRIMARY KEY, "string" TEXT, "fooId" TEXT, FOREIGN KEY ("fooId") REFERENCES "Foo" ("id"));`,
+        );
+
+        await dbRaw.$qb.insertInto('Foo').values({ id: '1', string: 'test' }).execute();
+        await dbRaw.$qb.insertInto('Bar').values({ id: '1', string: 'test', fooId: '1' }).execute();
+
+        expect(db.bar).toBeUndefined();
+
+        // unknown relation
+        await expect(db.foo.findFirst({ include: { bar: true } })).toBeRejectedByValidation();
+
+        // read
+        await expect(db.$qb.selectFrom('Bar').selectAll().execute()).toBeRejectedByPolicy();
+
+        // join
+        await expect(
+            db.$qb.selectFrom('Foo').innerJoin('Bar', 'Bar.fooId', 'Foo.id').selectAll().execute(),
+        ).toBeRejectedByPolicy();
+
+        // create
+        await expect(db.$qb.insertInto('Bar').values({ id: '1', string: 'test' }).execute()).toBeRejectedByPolicy();
+
+        // update
+        await expect(
+            db.$qb.updateTable('Bar').set({ string: 'updated' }).where('id', '=', '1').execute(),
+        ).toBeRejectedByPolicy();
+
+        // update with from
+        await expect(
+            db.$qb
+                .updateTable('Foo')
+                .set({ string: 'updated' })
+                .from('Bar')
+                .where('Bar.fooId', '=', 'Foo.id')
+                .execute(),
+        ).toBeRejectedByPolicy();
+
+        // delete
+        await expect(db.$qb.deleteFrom('Bar').where('id', '=', '1').execute()).toBeRejectedByPolicy();
+    });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy enforcement now correctly rejects operations targeting tables or models not defined in your schema.

* **Tests**
  * Added comprehensive test coverage verifying policy validation across read, create, update, and delete operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->