### PR TITLE
feat: split bump-version into bump-patch and bump-minor commands

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -2,6 +2,14 @@ name: Bump Version
 
 on:
     workflow_dispatch:
+        inputs:
+            version_type:
+                description: 'Version type to bump'
+                required: true
+                type: choice
+                options:
+                    - patch
+                    - minor
 
 permissions:
     contents: write
@@ -34,7 +42,7 @@ jobs:
 
             - name: Bump version
               id: bump
-              run: npx tsx scripts/bump-version.ts
+              run: npx tsx scripts/bump-version.ts ${{ inputs.version_type }}
 
             - name: Create PR
               uses: peter-evans/create-pull-request@v7

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "format": "prettier --write \"**/*.{ts,tsx,md}\"",
         "pr": "gh pr create --fill-first --base dev",
         "merge-main": "gh pr create --title \"merge dev to main\" --body \"\" --base main --head dev",
-        "bump-version": "gh workflow run .github/workflows/bump-version.yml --ref dev",
+        "bump-patch": "gh workflow run .github/workflows/bump-version.yml --ref dev -f version_type=patch",
+        "bump-minor": "gh workflow run .github/workflows/bump-version.yml --ref dev -f version_type=minor",
         "publish-all": "pnpm --filter \"./packages/**\" -r publish --access public",
         "publish-preview": "pnpm --filter \"./packages/**\" -r publish --force --registry https://preview.registry.zenstack.dev/",
         "unpublish-preview": "pnpm --filter \"./packages/**\" -r --shell-mode exec -- npm unpublish -f --registry https://preview.registry.zenstack.dev/ \"\\$PNPM_PACKAGE_NAME\""


### PR DESCRIPTION
## Summary

This PR separates the single `bump-version` command into two distinct commands for better version control:

- **`bump-patch`**: Increments the patch version (e.g., 3.0.5 → 3.0.6)
- **`bump-minor`**: Increments the minor version and resets patch to 0 (e.g., 3.0.5 → 3.1.0)

## Changes

### GitHub Actions Workflow ([.github/workflows/bump-version.yml](.github/workflows/bump-version.yml))
- Added `workflow_dispatch` input parameter `version_type` with choices "patch" or "minor"
- Updated the bump version step to pass the input to the script

### Bump Version Script ([scripts/bump-version.ts](scripts/bump-version.ts))
- Modified `incrementVersion()` function to accept a `type` parameter ('patch' | 'minor')
- Added command-line argument parsing to get the version type
- Added validation for the version type argument

### Package.json ([package.json](package.json))
- Removed: `"bump-version"`
- Added: `"bump-patch"` - triggers workflow with `version_type=patch`
- Added: `"bump-minor"` - triggers workflow with `version_type=minor`

## Usage

```bash
# To bump patch version (3.0.5 → 3.0.6)
pnpm run bump-patch

# To bump minor version (3.0.5 → 3.1.0)
pnpm run bump-minor
```

Both commands trigger the GitHub Actions workflow which creates a PR with the version changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version bumping workflow to support both patch and minor version increments with selectable options.
  * Split version bump scripts for streamlined version management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->