### PR TITLE
feat(orm): support where enum

### DIFF
--- a/tests/e2e/orm/client-api/name-mapping.test.ts
+++ b/tests/e2e/orm/client-api/name-mapping.test.ts
@@ -8,10 +8,10 @@ describe('Name mapping tests', () => {
     let db: ClientContract<SchemaType>;
 
     beforeEach(async () => {
-        db = (await createTestClient(schema, {
+        db = await createTestClient(schema, {
             usePrismaPush: true,
             schemaFile: path.join(__dirname, '../schemas/name-mapping/schema.zmodel'),
-        })) as any;
+        });
     });
 
     afterEach(async () => {
@@ -214,11 +214,7 @@ describe('Name mapping tests', () => {
         await expect(
             db.user.findMany({
                 where: {
-                    AND: [
-                        { role: { in: ['USER'] } },
-                        { role: { in: ['USER'] } },
-                        { OR: [{ role: { in: ['USER'] } }] },
-                    ],
+                    AND: [{ role: { in: ['USER'] } }, { role: { in: ['USER'] } }, { OR: [{ role: { in: ['USER'] } }] }],
                 },
                 select: {
                     email: true,
@@ -260,6 +256,38 @@ describe('Name mapping tests', () => {
                 .selectFrom('User')
                 .select(['User.email', 'User.role'])
                 .where('email', '=', 'u1@test.com')
+                .executeTakeFirst(),
+        ).resolves.toMatchObject({
+            email: 'u1@test.com',
+            role: 'USER',
+        });
+
+        // name mapping for enum value in where clause, with unqualified column name
+        await expect(
+            db.$qb.selectFrom('User').select(['User.email', 'User.role']).where('role', '=', 'USER').executeTakeFirst(),
+        ).resolves.toMatchObject({
+            email: 'u1@test.com',
+            role: 'USER',
+        });
+
+        // name mapping for enum value in simple where clause, with qualified column name
+        await expect(
+            db.$qb
+                .selectFrom('User as u')
+                .select(['u.email', 'u.role'])
+                .where('u.role', '=', 'USER')
+                .executeTakeFirst(),
+        ).resolves.toMatchObject({
+            email: 'u1@test.com',
+            role: 'USER',
+        });
+
+        // enum value in list
+        await expect(
+            db.$qb
+                .selectFrom('User')
+                .select(['User.email', 'User.role'])
+                .where('role', 'in', ['USER', 'ADMIN'])
                 .executeTakeFirst(),
         ).resolves.toMatchObject({
             email: 'u1@test.com',


### PR DESCRIPTION
Use transformWhere to handle mapping of enum values

Closes #541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved enum/value mapping in WHERE-style binary operations so equality and IN filters correctly match mapped values across qualified, unqualified, aliased, and nested column references.

* **Tests**
  * Expanded end-to-end tests covering raw queries, ORM reads, findFirst/findMany with single and array filters, combined AND/OR conditions, aliases, and nested selections to validate consistent enum/name mapping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->