### PR TITLE
feat: rpc custom api methods

### DIFF
--- a/packages/clients/tanstack-query/src/common/types.ts
+++ b/packages/clients/tanstack-query/src/common/types.ts
@@ -76,3 +76,15 @@ type WithOptimisticFlag<T> = T extends object
     : T;
 
 export type WithOptimistic<T> = T extends Array<infer U> ? Array<WithOptimisticFlag<U>> : WithOptimisticFlag<T>;
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+
+export type CustomOperationKind = 'query' | 'suspenseQuery' | 'infiniteQuery' | 'suspenseInfiniteQuery' | 'mutation';
+
+export type CustomOperationDefinition<TArgs = unknown, TResult = unknown> = {
+    kind: CustomOperationKind;
+    method?: HttpMethod;
+    /** Phantom fields for typing */
+    __args?: TArgs;
+    __result?: TResult;
+};

--- a/packages/server/src/api/index.ts
+++ b/packages/server/src/api/index.ts
@@ -1,2 +1,9 @@
 export { RestApiHandler, type RestApiHandlerOptions } from './rest';
-export { RPCApiHandler, type RPCApiHandlerOptions } from './rpc';
+export {
+	RPCBadInputErrorResponse,
+	RPCGenericErrorResponse,
+	RPCApiHandler,
+	type RPCApiHandlerOptions,
+	type RPCCustomOperation,
+	type RPCCustomOperationContext,
+} from './rpc';


### PR DESCRIPTION
* Provides an ability to create custom operations
* Refactors argument handling for simplification
* Forces operation names to follow JS function naming rules
* Adds the ability to modify the tanstack-query to add in the custom operation on the client side

Some Quick Documentation on Usage:

## Server: RPCApiHandler

### Defining custom operations

```ts
import {
   RPCApiHandler,
   RPCBadInputErrorResponse,
   RPCGenericErrorResponse,
   type RPCApiHandlerOptions,
   type RPCCustomOperation,
} from '@zenstackhq/server';

const customOperations: Record<string, RPCCustomOperation> = {
    overview: async ({ client, model, args }) => {
        if (model !== "report") {
            throw RPCGenericErrorResponse("Invalid endpoint");
        }

        const { since } = (args ?? {}) as { since?: string };
        const sinceDate = since ? new Date(since) : undefined;

        const [activeUsers, posts, comments] = await Promise.all([
            client.user.count({ where: sinceDate ? { updatedAt: { gte: sinceDate } } : {} }),
            client.post.count({ where: sinceDate ? { createdAt: { gte: sinceDate } } : {} }),
            client.comment.count({ where: sinceDate ? { createdAt: { gte: sinceDate } } : {} }),
        ]);

        return { status: 200, body: { data: { activeUsers, posts, comments } } };
    },
    bulkDisable: async ({ client, model, args }) => {
        if (!ALLOWED.has(model)) {
            throw new RPCBadInputErrorResponse(`unsupported model: ${model}`);
        }

        const { ids } = (args ?? {}) as { ids?: string[] };
        if (!ids?.length) {
            throw new RPCBadInputErrorResponse('ids is required');
        }

        const result = await (client as any)[model].updateMany({
            where: { id: { in: ids } },
            data: { disabled: true },
        });

        return { status: 200, body: { data: result.count } };
    },
    search: async ({ client, model, args }) => {
        if (!['post', 'comment'].includes(model)) {
            throw new RPCBadInputErrorResponse(`search not allowed for model ${model}`);
        }

        const { search } = (args ?? {}) as { search?: string };
        if (!search) {
            throw new RPCBadInputErrorResponse('search is required');
        }

        const data = await (client as any)[model].findMany({
            where: { content: { contains: search, mode: 'insensitive' } },
            take: 20,
        });

        return { status: 200, body: { data } };
    },
};


const handler = new RPCApiHandler({
   schema: client.$schema,
   customOperations,
} satisfies RPCApiHandlerOptions);
```

### Error handling

- Throw `RPCBadInputErrorResponse` for user input issues → returns HTTP 400.
- Throw `RPCGenericErrorResponse` (or any other error) → returns HTTP 500.
- Throw `ORMError` → mapped to the corresponding ORM-aware status/shape.

### Automatic `q/meta` unmarshal

If the request includes `q` and `meta` query params, the handler automatically deserializes them (SuperJSON-aware) before invoking the custom operation. The custom operation receives the parsed value on `args` and also on `query.q`.

### Request context provided to custom ops

```ts
{
   client,          // Zenstack client
   method,          // HTTP method
   path,            // original path
   query,           // parsed query with q/meta handled
   requestBody,     // raw body (if any)
   model,           // lower-cased model segment from the path
   operation,       // operation segment from the path
   args,            // parsed q/meta if present
}
```

## Client: TanStack Query runtimes

Each runtime can register custom operations so they are callable like built-ins via generated hooks.

### Define custom operations config

A custom operation definition specifies the hook kind and HTTP method (for mutations):
```ts
import type { CustomOperationDefinition } from '@zenstackhq/tanstack-query/src/common/types';
import { useClientQueries } from '@zenstackhq/tanstack-query/react';
import { schema } from './generated/schema';

const customOps = {
    overview: { kind: 'query' } satisfies CustomOperationDefinition, // used under the virtual model "report"
    bulkDisable: { kind: 'mutation', method: 'POST' } satisfies CustomOperationDefinition,
    search: { kind: 'query' } satisfies CustomOperationDefinition,
} as const;

const hooks = useClientQueries(schema, { endpoint: '/api/model' }, customOps);

// Virtual model call: GET /api/model/report/overview?q={...}
const report = hooks.report.useOverview({ query: { q: { since: '2024-01-01' } } });

// Model-aware mutation: POST /api/model/user/bulkDisable
const { mutateAsync: disableUsers } = hooks.user.useBulkDisable();
await disableUsers({ ids: ['u1', 'u2'] });

// Custom query with validation: GET /api/model/post/search?q={"search":"zen"}
const posts = hooks.post.useSearch({ query: { q: { search: 'zen' } } });
```

### Notes and constraints
- Custom operation names must be valid JS identifiers and cannot shadow built-in RPC operations.
- Infinite custom queries receive a default `getNextPageParam` if not supplied.
- Hook names are generated as `use<CapitalizedOp>` per model namespace (e.g., `hooks.post.useEcho`).
- Payload serialization follows the same SuperJSON contract as built-in operations.

## End-to-end flow
1) Add server custom operations to `RPCApiHandler` and deploy endpoint (e.g., `/api/model/<model>/<op>`).
2) Define matching client `customOperations` config in TanStack Query runtime and call generated hooks.
3) Use RPC error classes in server custom ops to produce consistent responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom operations across React, Svelte, and Vue client implementations with automatic type inference.
  * Enhanced RPC API handler with custom operation execution and error mapping capabilities.

* **Tests**
  * Added comprehensive test coverage for custom operation execution, error handling, and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->