### PR TITLE
fix(orm): incorrect result type when "_count" is nested inside "include"

### DIFF
--- a/packages/orm/src/client/crud-types.ts
+++ b/packages/orm/src/client/crud-types.ts
@@ -214,7 +214,11 @@ export type ModelResult<
                     ModelFieldIsOptional<Schema, Model, Key>,
                     FieldIsArray<Schema, Model, Key>
                 >;
-            }
+            } & ('_count' extends keyof I
+                ? I['_count'] extends false | undefined
+                    ? {}
+                    : { _count: SelectCountResult<Schema, Model, I['_count']> }
+                : {})
           : Args extends { omit: infer O } & Record<string, unknown>
             ? DefaultModelResult<Schema, Model, O, Options, false, false>
             : DefaultModelResult<Schema, Model, undefined, Options, false, false>,

--- a/tests/e2e/orm/client-api/find.test.ts
+++ b/tests/e2e/orm/client-api/find.test.ts
@@ -1122,6 +1122,52 @@ describe('Client find tests ', () => {
         });
     });
 
+    it('supports _count inside include', async () => {
+        const user = await createUser(client, 'u1@test.com');
+        await createPosts(client, user.id);
+
+        // Test _count with select inside include
+        const result = await client.user.findFirst({
+            include: {
+                posts: { select: { title: true } },
+                _count: { select: { posts: true } },
+            },
+        });
+
+        expect(result).toBeDefined();
+        expect(result?.posts).toHaveLength(2);
+        expect(result?.posts[0]).toHaveProperty('title');
+        // TypeScript should recognize _count property exists
+        expect(result?._count).toBeDefined();
+        expect(result?._count.posts).toBe(2);
+
+        // Test _count with boolean true inside include
+        const result2 = await client.user.findFirst({
+            include: {
+                posts: true,
+                _count: true,
+            },
+        });
+
+        expect(result2).toBeDefined();
+        expect(result2?.posts).toHaveLength(2);
+        expect(result2?._count).toBeDefined();
+        expect(result2?._count.posts).toBe(2);
+
+        // Test _count with filtered posts inside include
+        const result3 = await client.user.findFirst({
+            include: {
+                posts: { where: { published: true } },
+                _count: { select: { posts: { where: { published: true } } } },
+            },
+        });
+
+        expect(result3).toBeDefined();
+        expect(result3?.posts).toHaveLength(1);
+        expect(result3?._count).toBeDefined();
+        expect(result3?._count.posts).toBe(1);
+    });
+
     it('supports $expr', async () => {
         await createUser(client, 'yiming@gmail.com');
         await createUser(client, 'yiming@zenstack.dev');

--- a/tests/e2e/orm/schemas/typing/typecheck.ts
+++ b/tests/e2e/orm/schemas/typing/typecheck.ts
@@ -162,6 +162,25 @@ async function find() {
         })
     ).profile?.region?.city;
 
+    // _count inside include should be properly typed
+    const includeWithCount = await client.user.findFirst({
+        include: {
+            posts: { select: { title: true } },
+            _count: { select: { posts: true } },
+        },
+    });
+    console.log(includeWithCount?.posts[0]?.title);
+    console.log(includeWithCount?._count.posts);
+
+    const includeWithCountTrue = await client.user.findFirst({
+        include: {
+            posts: true,
+            _count: true,
+        },
+    });
+    console.log(includeWithCountTrue?.posts[0]?.title);
+    console.log(includeWithCountTrue?._count.posts);
+
     (
         await client.user.findFirstOrThrow({
             select: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added support for selecting count information on related records using `_count` within include queries. Retrieve aggregate counts alongside related data in a single operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->