### PR TITLE
feat: add template literal types for formatted ids

### DIFF
--- a/packages/language/package.json
+++ b/packages/language/package.json
@@ -56,6 +56,7 @@
     },
     "dependencies": {
         "@zenstackhq/common-helpers": "workspace:*",
+        "@zenstackhq/schema": "workspace:*",
         "langium": "catalog:",
         "pluralize": "^8.0.0",
         "ts-pattern": "catalog:",

--- a/packages/language/src/validators/function-invocation-validator.ts
+++ b/packages/language/src/validators/function-invocation-validator.ts
@@ -1,3 +1,4 @@
+import { ID_GENERATOR_FUNCTIONS } from '@zenstackhq/schema';
 import { AstUtils, type AstNode, type ValidationAcceptor } from 'langium';
 import { match, P } from 'ts-pattern';
 import { ExpressionContext } from '../constants';
@@ -88,7 +89,7 @@ export default class FunctionInvocationValidator implements AstValidator<Express
             }
         }
 
-        if (['uuid', 'ulid', 'cuid', 'nanoid'].includes(funcDecl.name)) {
+        if (ID_GENERATOR_FUNCTIONS.includes(funcDecl.name as typeof ID_GENERATOR_FUNCTIONS[number])) {
             const formatParamIdx = funcDecl.params.findIndex((param) => param.name === 'format');
             const formatArg = getLiteral<string>(expr.args[formatParamIdx]?.value);
             if (

--- a/packages/orm/src/client/crud-types.ts
+++ b/packages/orm/src/client/crud-types.ts
@@ -35,6 +35,7 @@ import type {
 import type {
     AtLeast,
     MapBaseType,
+    MapStringWithFormat,
     MaybePromise,
     NonEmptyArray,
     NullableIf,
@@ -970,14 +971,16 @@ type MapModelFieldType<
 
 type MapFieldDefType<
     Schema extends SchemaDef,
-    T extends Pick<FieldDef, 'type' | 'optional' | 'array'>,
+    T extends Pick<FieldDef, 'type' | 'optional' | 'array' | 'default'>,
     Partial extends boolean = false,
 > = WrapType<
     T['type'] extends GetEnums<Schema>
         ? keyof GetEnum<Schema, T['type']>
         : T['type'] extends GetTypeDefs<Schema>
           ? TypeDefResult<Schema, T['type'], Partial> & Record<string, unknown>
-          : MapBaseType<T['type']>,
+          : T['type'] extends 'String'
+            ? MapStringWithFormat<T['default']>
+            : MapBaseType<T['type']>,
     T['optional'],
     T['array']
 >;

--- a/packages/orm/src/utils/type-utils.ts
+++ b/packages/orm/src/utils/type-utils.ts
@@ -95,9 +95,12 @@ export type UnwrapTuplePromises<T extends readonly unknown[]> = {
 /**
  * Converts a format string like "user_%s" to a template literal type like `user_${string}`.
  * Supports multiple %s placeholders: "pre_%s_mid_%s" -> `pre_${string}_mid_${string}`
+ * Handles escaped \%s which becomes literal %s: "\\%s_%s" -> `%s_${string}`
  */
 export type FormatToTemplateLiteral<F extends string> = F extends `${infer Prefix}%s${infer Suffix}`
-    ? `${Prefix}${string}${FormatToTemplateLiteral<Suffix>}`
+    ? Prefix extends `${infer P}\\`
+        ? `${P}%s${FormatToTemplateLiteral<Suffix>}` // Escaped \%s -> literal %s
+        : `${Prefix}${string}${FormatToTemplateLiteral<Suffix>}` // Unescaped %s -> ${string}
     : F;
 
 /**

--- a/packages/orm/test/type-utils.test.ts
+++ b/packages/orm/test/type-utils.test.ts
@@ -1,0 +1,141 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type {
+    ExtractIdFormat,
+    FormatToTemplateLiteral,
+    MapStringWithFormat,
+} from '../src/utils/type-utils';
+
+describe('FormatToTemplateLiteral', () => {
+    it('converts simple prefix format to template literal', () => {
+        expectTypeOf<FormatToTemplateLiteral<'user_%s'>>().toEqualTypeOf<`user_${string}`>();
+    });
+
+    it('converts simple suffix format to template literal', () => {
+        expectTypeOf<FormatToTemplateLiteral<'%s_suffix'>>().toEqualTypeOf<`${string}_suffix`>();
+    });
+
+    it('converts multiple placeholders to template literal', () => {
+        expectTypeOf<FormatToTemplateLiteral<'pre_%s_mid_%s'>>().toEqualTypeOf<`pre_${string}_mid_${string}`>();
+    });
+
+    it('preserves string without placeholders', () => {
+        expectTypeOf<FormatToTemplateLiteral<'no_placeholder'>>().toEqualTypeOf<'no_placeholder'>();
+    });
+
+    it('handles escaped \\%s as literal %s', () => {
+        expectTypeOf<FormatToTemplateLiteral<'\\%s_end'>>().toEqualTypeOf<'%s_end'>();
+    });
+
+    it('handles mixed escaped and unescaped - unescaped first', () => {
+        expectTypeOf<FormatToTemplateLiteral<'%s_\\%s'>>().toEqualTypeOf<`${string}_%s`>();
+    });
+
+    it('handles mixed escaped and unescaped - escaped first', () => {
+        expectTypeOf<FormatToTemplateLiteral<'\\%s_%s'>>().toEqualTypeOf<`%s_${string}`>();
+    });
+
+    it('handles multiple escaped placeholders', () => {
+        expectTypeOf<FormatToTemplateLiteral<'\\%s_\\%s'>>().toEqualTypeOf<'%s_%s'>();
+    });
+
+    it('handles complex mixed pattern', () => {
+        expectTypeOf<FormatToTemplateLiteral<'pre_\\%s_%s_\\%s_end'>>().toEqualTypeOf<`pre_%s_${string}_%s_end`>();
+    });
+});
+
+describe('ExtractIdFormat', () => {
+    it('extracts format from uuid call with format arg', () => {
+        type UuidCall = {
+            kind: 'call';
+            function: 'uuid';
+            args: readonly [{ kind: 'literal'; value: 4 }, { kind: 'literal'; value: 'user_%s' }];
+        };
+        expectTypeOf<ExtractIdFormat<UuidCall>>().toEqualTypeOf<'user_%s'>();
+    });
+
+    it('extracts format from cuid call with format arg', () => {
+        type CuidCall = {
+            kind: 'call';
+            function: 'cuid';
+            args: readonly [{ kind: 'literal'; value: 2 }, { kind: 'literal'; value: 'post_%s' }];
+        };
+        expectTypeOf<ExtractIdFormat<CuidCall>>().toEqualTypeOf<'post_%s'>();
+    });
+
+    it('extracts format from nanoid call with format arg', () => {
+        type NanoidCall = {
+            kind: 'call';
+            function: 'nanoid';
+            args: readonly [{ kind: 'literal'; value: 21 }, { kind: 'literal'; value: 'nano_%s' }];
+        };
+        expectTypeOf<ExtractIdFormat<NanoidCall>>().toEqualTypeOf<'nano_%s'>();
+    });
+
+    it('extracts format from ulid call (format is first arg)', () => {
+        type UlidCall = {
+            kind: 'call';
+            function: 'ulid';
+            args: readonly [{ kind: 'literal'; value: 'ulid_%s' }];
+        };
+        expectTypeOf<ExtractIdFormat<UlidCall>>().toEqualTypeOf<'ulid_%s'>();
+    });
+
+    it('returns never for uuid call without format arg', () => {
+        type UuidNoFormat = {
+            kind: 'call';
+            function: 'uuid';
+            args: readonly [{ kind: 'literal'; value: 4 }];
+        };
+        expectTypeOf<ExtractIdFormat<UuidNoFormat>>().toEqualTypeOf<never>();
+    });
+
+    it('returns never for non-id-generator call', () => {
+        type OtherCall = {
+            kind: 'call';
+            function: 'now';
+            args: readonly [];
+        };
+        expectTypeOf<ExtractIdFormat<OtherCall>>().toEqualTypeOf<never>();
+    });
+
+    it('returns never for undefined', () => {
+        expectTypeOf<ExtractIdFormat<undefined>>().toEqualTypeOf<never>();
+    });
+});
+
+describe('MapStringWithFormat', () => {
+    it('returns template literal for uuid with format', () => {
+        type UuidCall = {
+            kind: 'call';
+            function: 'uuid';
+            args: readonly [{ kind: 'literal'; value: 4 }, { kind: 'literal'; value: 'user_%s' }];
+        };
+        expectTypeOf<MapStringWithFormat<UuidCall>>().toEqualTypeOf<`user_${string}`>();
+    });
+
+    it('returns plain string for uuid without format', () => {
+        type UuidNoFormat = {
+            kind: 'call';
+            function: 'uuid';
+            args: readonly [{ kind: 'literal'; value: 4 }];
+        };
+        expectTypeOf<MapStringWithFormat<UuidNoFormat>>().toEqualTypeOf<string>();
+    });
+
+    it('returns plain string for undefined default', () => {
+        expectTypeOf<MapStringWithFormat<undefined>>().toEqualTypeOf<string>();
+    });
+
+    it('returns plain string for non-call default', () => {
+        expectTypeOf<MapStringWithFormat<'static-value'>>().toEqualTypeOf<string>();
+    });
+
+    it('handles escaped format in uuid call', () => {
+        type UuidEscaped = {
+            kind: 'call';
+            function: 'uuid';
+            args: readonly [{ kind: 'literal'; value: 4 }, { kind: 'literal'; value: '\\%s_%s' }];
+        };
+        expectTypeOf<MapStringWithFormat<UuidEscaped>>().toEqualTypeOf<`%s_${string}`>();
+    });
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,3 +1,3 @@
 export type * from './expression';
 export * from './expression-utils';
-export type * from './schema';
+export * from './schema';

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -315,3 +315,13 @@ export type FieldIsDelegateDiscriminator<
 > = GetModelField<Schema, Model, Field>['isDiscriminator'] extends true ? true : false;
 
 //#endregion
+
+//#region Field defaults
+
+/**
+ * ID generator functions that support format strings (e.g., uuid(4, "user_%s"))
+ */
+export const ID_GENERATOR_FUNCTIONS = ['uuid', 'cuid', 'nanoid', 'ulid'] as const;
+export type IdGeneratorFunction = (typeof ID_GENERATOR_FUNCTIONS)[number];
+
+//#endregion


### PR DESCRIPTION
Marking this as a draft, as it still requires more work & I was wanting input from the maintainers.

**Idea:**
Allow for the TS types of the newly (optionally) formatted IDs to narrow to `prefix_{string}` as opposed to just `string`:

```ts
type User = {
   // new behaviour
   id: `user_{string}`;
   // old behaviour
   id: string;
}
```

Motivations:
* It provides a great level of granularity to type-safety, e.g.:

```ts
const fetchUser = (userId: User["id"]) => {
   // would ensure that no random strings can enter the function
}
```

Concerns:
* will be a breaking change to people's types (but not their runtime), as some (like myself) may have already been using `User["id"]` with the assumption that it casts to a `string`
  * IMO, it would be a sane default, as most people that are prefixing their IDs are generally working in repos where type-safety is crucial
  * but if you disagree, we could potentially add a flag e.g. `narrowType` or something (defaults to `false`)
* TS performance of these ternaries
