### PR TITLE
externalIdMapping: optionally allow using mapped unique index names

### DIFF
--- a/packages/server/src/api/rest/index.ts
+++ b/packages/server/src/api/rest/index.ts
@@ -1344,7 +1344,7 @@ export class RestApiHandler<Schema extends SchemaDef = SchemaDef> implements Api
             if (name === externalIdName) {
                 if (typeof info.type === 'string') {
                     // single unique field
-                    return [this.requireField(model, info.type)];
+                    return [this.requireField(model, name)];
                 } else {
                     // compound unique fields
                     return Object.keys(info).map((f) => this.requireField(model, f));

--- a/packages/server/test/api/rest.test.ts
+++ b/packages/server/test/api/rest.test.ts
@@ -3183,6 +3183,7 @@ describe('REST server tests', () => {
     model Post {
         id Int @id @default(autoincrement())
         title String
+        short_title String @unique()
         author User? @relation(fields: [authorId], references: [id])
         authorId Int?
     }
@@ -3195,6 +3196,7 @@ describe('REST server tests', () => {
                 endpoint: 'http://localhost/api',
                 externalIdMapping: {
                     User: 'name_source',
+                    Post: 'short_title',
                 },
             });
             handler = (args) => _handler.handleRequest({ ...args, url: new URL(`http://localhost/${args.path}`) });
@@ -3229,13 +3231,13 @@ describe('REST server tests', () => {
             expect(r.body.data.attributes.name).toBe('User1');
 
             await client.post.create({
-                data: { id: 1, title: 'Title1', authorId: 1 },
+                data: { id: 1, title: 'Title1', short_title: 'post-title-1', authorId: 1 },
             });
 
             // post is exposed using the `id` field
             r = await handler({
                 method: 'get',
-                path: '/post/1',
+                path: '/post/post-title-1',
                 query: { include: 'author' },
                 client,
             });


### PR DESCRIPTION
so the actual bug is more trivial and somehow my brain totally misfired in the initial analysis.

fixes https://github.com/zenstackhq/zenstack-v3/issues/611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for identifying models by compound external ID keys remains available.

* **Bug Fixes**
  * ID resolution for single-field unique mappings now resolves using the configured external ID field name (improves lookup consistency); compound-key behavior unchanged.
  * Public API signatures were not changed.

* **Tests**
  * Test schema and flows updated to add a short_title external ID for posts and to validate retrieval via external IDs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->