### PR TITLE
add test for pg computed values across multiple schema

### DIFF
--- a/tests/e2e/orm/client-api/pg-computed-multischema.test.ts
+++ b/tests/e2e/orm/client-api/pg-computed-multischema.test.ts
@@ -39,7 +39,7 @@ describe('Postgres multi-schema with computed fields', () => {
                             .limit(1)
                     },
                 },
-            }
+            } as any
         );
 
         // Create author and book


### PR DESCRIPTION
This tests shows that https://github.com/zenstackhq/zenstack-v3/issues/614 can be closed. Not sure if its worth adding this test, given that the two features are being tests independently already.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test coverage validating computed fields in a multi-schema Postgres setup, ensuring cross-schema relations resolve correctly and computed values (e.g., derived author name) are returned as expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->