### PR TITLE
fix(cli): properly quote prisma exec path

### DIFF
--- a/packages/cli/src/utils/exec-utils.ts
+++ b/packages/cli/src/utils/exec-utils.ts
@@ -57,5 +57,5 @@ export function execPrisma(args: string, options?: Omit<ExecSyncOptions, 'env'> 
         return;
     }
 
-    execSync(`node ${prismaPath} ${args}`, _options);
+    execSync(`node "${prismaPath}" ${args}`, _options);
 }


### PR DESCRIPTION
fixes #609


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the CLI where Prisma execution would fail when the installation path contained spaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->