### PR TITLE
fix(language): resolve mixin fields from imported files in scope (#598)

### DIFF
--- a/packages/language/src/zmodel-scope.ts
+++ b/packages/language/src/zmodel-scope.ts
@@ -80,7 +80,7 @@ export class ZModelScopeComputation extends DefaultScopeComputation {
         super.processNode(node, document, scopes);
         if (isDataModel(node) || isTypeDef(node)) {
             // add base fields to the scope recursively
-            const bases = getRecursiveBases(node);
+            const bases = getRecursiveBases(node, true, this.services.shared.workspace.LangiumDocuments);
             for (const base of bases) {
                 for (const field of base.fields) {
                     scopes.add(node, this.descriptions.createDescription(field, this.nameProvider.getName(field)));

--- a/packages/testtools/src/client.ts
+++ b/packages/testtools/src/client.ts
@@ -68,7 +68,12 @@ type ExtraTestClientOptions = {
     usePrismaPush?: boolean;
 
     /**
-     * Extra source files to create and compile.
+     * Extra ZModel files to be created in the working directory.
+     */
+    extraZModelFiles?: Record<string, string>;
+
+    /**
+     * Extra TypeScript source files to create and compile.
      */
     extraSourceFiles?: Record<string, string>;
 
@@ -126,7 +131,14 @@ export async function createTestClient(
     let model: Model | undefined;
 
     if (typeof schema === 'string') {
-        const generated = await generateTsSchema(schema, provider, dbUrl, options?.extraSourceFiles, undefined);
+        const generated = await generateTsSchema(
+            schema,
+            provider,
+            dbUrl,
+            options?.extraSourceFiles,
+            undefined,
+            options?.extraZModelFiles,
+        );
         workDir = generated.workDir;
         model = generated.model;
         // replace schema's provider

--- a/packages/testtools/src/schema.ts
+++ b/packages/testtools/src/schema.ts
@@ -61,6 +61,7 @@ export async function generateTsSchema(
     dbUrl?: string,
     extraSourceFiles?: Record<string, string>,
     withLiteSchema?: boolean,
+    extraZModelFiles?: Record<string, string>,
 ) {
     const workDir = createTestProject();
 
@@ -70,6 +71,19 @@ export async function generateTsSchema(
         zmodelPath,
         `${noPrelude ? '' : makePrelude(provider, dbUrl)}\n\n${replacePlaceholders(schemaText, provider, dbUrl)}`,
     );
+
+    // write extra ZModel files before loading the schema
+    if (extraZModelFiles) {
+        for (const [fileName, content] of Object.entries(extraZModelFiles)) {
+            let name = fileName;
+            if (!name.endsWith('.zmodel')) {
+                name += '.zmodel';
+            }
+            const filePath = path.join(workDir, name);
+            fs.mkdirSync(path.dirname(filePath), { recursive: true });
+            fs.writeFileSync(filePath, content);
+        }
+    }
 
     const result = await loadDocumentWithPlugins(zmodelPath);
     if (!result.success) {

--- a/tests/regression/test/issue-598.test.ts
+++ b/tests/regression/test/issue-598.test.ts
@@ -1,0 +1,79 @@
+import { createPolicyTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+describe('Regression for issue 598', () => {
+    it('access policy can reference mixin fields from imported files', async () => {
+        const db = await createPolicyTestClient(
+            `
+import './mixins'
+
+datasource db {
+    provider = 'postgresql'
+    url = '$DB_URL'
+}
+
+model User {
+    id Int @id @default(autoincrement())
+    email String @unique
+    documents Document[]
+
+    @@allow('all', true)
+}
+
+model Document with AuditMixin {
+    id String @id @default(cuid())
+    title String
+    ownerId Int
+    owner User @relation(fields: [ownerId], references: [id])
+
+    @@allow('create,read', auth() != null)
+    @@allow('update', auth().id == createdById)  // createdById from mixin
+}
+            `,
+            {
+                extraZModelFiles: {
+                    mixins: `
+type AuditMixin {
+    createdById Int
+    createdAt DateTime @default(now())
+}
+                    `,
+                },
+            },
+        );
+
+        // Test that the policy rule using mixin field works correctly
+        const userDb = db.$setAuth({ id: 1 });
+        const otherUserDb = db.$setAuth({ id: 2 });
+
+        // Create users first
+        await db.user.create({ data: { id: 1, email: 'user1@test.com' } });
+        await db.user.create({ data: { id: 2, email: 'user2@test.com' } });
+
+        // Create document as user 1
+        await userDb.document.create({
+            data: {
+                id: 'doc-1',
+                title: 'Test Document',
+                ownerId: 1,
+                createdById: 1, // From mixin
+            },
+        });
+
+        // User 1 should be able to update (matches createdById)
+        await expect(
+            userDb.document.update({
+                where: { id: 'doc-1' },
+                data: { title: 'Updated' },
+            }),
+        ).toResolveTruthy();
+
+        // User 2 should NOT be able to update (different createdById)
+        await expect(
+            otherUserDb.document.update({
+                where: { id: 'doc-1' },
+                data: { title: 'Hacked' },
+            }),
+        ).toBeRejectedNotFound();
+    });
+});


### PR DESCRIPTION
Fixed issue where access policy rules couldn't reference fields inherited from mixins defined in separate imported files. The language service now correctly resolves these fields during scope computation.

## Root Cause

The `getRecursiveBases()` function only searched for mixin declarations in the current document (`decl.$container.declarations`), which failed for imported mixins.

## Solution

- Modified `getRecursiveBases()` to accept optional `LangiumDocuments` parameter
- Implemented two-strategy approach:
  1. Use resolved reference if available (post-linking)
  2. Search by name across all documents including imports (pre-linking)
- Updated `ZModelScopeComputation.processNode()` to pass `LangiumDocuments`
- Leverages existing `getAllDeclarationsIncludingImports()` helper

## Changes

- **packages/language/src/utils.ts**: Fixed `getRecursiveBases()` to search imported documents
- **packages/language/src/zmodel-scope.ts**: Pass LangiumDocuments to scope computation
- **packages/language/test/mixin.test.ts**: Added tests for imported mixin field resolution
- **packages/testtools**: Added `extraZModelFiles` option for multi-file test schemas
- **tests/regression/test/issue-598.test.ts**: Regression test for the issue

## Test Results

✅ All language package tests pass (65 tests)
✅ Regression test validates policy rules can access imported mixin fields
✅ Handles edge cases: cyclic imports, nested mixins, transitive imports

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for referencing mixin fields across imported files in access policies.

* **Bug Fixes**
  * Fixed unresolved references when access rules reference fields from imported mixins.

* **Tests**
  * Added test coverage for mixin behavior in multi-file scenarios.
  * Added regression test validating policy rules can access imported mixin fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->