### PR TITLE
validate computed field configuration  on startup

### DIFF
--- a/packages/testtools/src/client.ts
+++ b/packages/testtools/src/client.ts
@@ -104,6 +104,11 @@ type ExtraTestClientOptions = {
         globPattern: string;
         destination: string;
     }[];
+
+    /**
+     * Computed fields configuration for tests.
+     */
+    computedFields?: import('@zenstackhq/orm').ComputedFieldsOptions<any>;
 };
 
 export type CreateTestClientOptions<Schema extends SchemaDef> = Omit<ClientOptions<Schema>, 'dialect'> &


### PR DESCRIPTION
Note on the changes to the existing tests:

The type-checking tests contain duplicate configurations:

Outer config (required by createTestClient): Needed to instantiate the actual client. Without it, the new runtime validation throws an error before the test can run.

Inner config (in extraSourceFiles): Example code that demonstrates proper usage and ensures the generated TypeScript file compiles with correct type hints.

This duplication is a consequence of using createTestClient for type-checking. The outer config satisfies the runtime validation, while the inner config serves as realistic documentation of how users should structure their code.

Let me know if you would prefer adding a helper to side-step createTestClient for these cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ORM client now validates computed-field configurations during initialization and raises clear errors if a computed field is missing or misconfigured.

* **New Features**
  * Test client options now accept an optional computed-fields configuration to provide computed-field behavior in tests.

* **Tests**
  * Added end-to-end tests for computed-field validation, error cases (missing or non-function configs), and typed/runtime behaviors across workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->