### PR TITLE
feat(orm): add support for runtime virtual fields

### DIFF
--- a/packages/language/res/stdlib.zmodel
+++ b/packages/language/res/stdlib.zmodel
@@ -644,9 +644,13 @@ attribute @json() @@@targetField([TypeDefField])
 attribute @computed()
 
 /**
- * Marks a field to be virtual
+ * Marks a field to be virtual (computed at runtime in JavaScript).
+ *
+ * @param dependencies: A list of fields that this virtual field depends on. When the virtual field
+ * is selected, these fields will be automatically included in the database query even if not
+ * explicitly selected by the user, and will be stripped from the result after computation.
  */
-attribute @virtual()
+attribute @virtual(dependencies: FieldReference[]?)
 
 /**
  * Gets the current login user.

--- a/packages/language/res/stdlib.zmodel
+++ b/packages/language/res/stdlib.zmodel
@@ -623,6 +623,11 @@ attribute @json() @@@targetField([TypeDefField])
 attribute @computed()
 
 /**
+ * Marks a field to be virtual
+ */
+attribute @virtual()
+
+/**
  * Gets the current login user.
  */
 function auth(): Any {

--- a/packages/language/src/utils.ts
+++ b/packages/language/src/utils.ts
@@ -154,6 +154,13 @@ export function isComputedField(field: DataField) {
     return hasAttribute(field, '@computed');
 }
 
+/**
+ * Returns if the given field is a virtual field.
+ */
+export function isVirtualField(field: DataField) {
+    return hasAttribute(field, '@virtual');
+}
+
 export function isDelegateModel(node: AstNode) {
     return isDataModel(node) && hasAttribute(node, '@@delegate');
 }

--- a/packages/orm/src/client/client-impl.ts
+++ b/packages/orm/src/client/client-impl.ts
@@ -456,7 +456,7 @@ function createModelCrudHandler(
                 }
                 let result: unknown;
                 if (r && postProcess) {
-                    result = resultProcessor.processResult(r, model, args, client.$auth);
+                    result = await resultProcessor.processResult(r, model, args, client.$auth);
                 } else {
                     result = r ?? null;
                 }

--- a/packages/orm/src/client/client-impl.ts
+++ b/packages/orm/src/client/client-impl.ts
@@ -456,7 +456,7 @@ function createModelCrudHandler(
                 }
                 let result: unknown;
                 if (r && postProcess) {
-                    result = await resultProcessor.processResult(r, model, args, client);
+                    result = await resultProcessor.processResult(r, model, args, txClient ?? client);
                 } else {
                     result = r ?? null;
                 }

--- a/packages/orm/src/client/client-impl.ts
+++ b/packages/orm/src/client/client-impl.ts
@@ -456,7 +456,7 @@ function createModelCrudHandler(
                 }
                 let result: unknown;
                 if (r && postProcess) {
-                    result = resultProcessor.processResult(r, model, args);
+                    result = resultProcessor.processResult(r, model, args, client.$auth);
                 } else {
                     result = r ?? null;
                 }

--- a/packages/orm/src/client/client-impl.ts
+++ b/packages/orm/src/client/client-impl.ts
@@ -456,7 +456,7 @@ function createModelCrudHandler(
                 }
                 let result: unknown;
                 if (r && postProcess) {
-                    result = await resultProcessor.processResult(r, model, args, client.$auth);
+                    result = await resultProcessor.processResult(r, model, args, client);
                 } else {
                     result = r ?? null;
                 }

--- a/packages/orm/src/client/crud-types.ts
+++ b/packages/orm/src/client/crud-types.ts
@@ -1666,7 +1666,9 @@ type NumericFields<Schema extends SchemaDef, Model extends GetModels<Schema>> = 
         | 'Decimal'
         ? FieldIsArray<Schema, Model, Key> extends true
             ? never
-            : Key
+            : FieldIsVirtual<Schema, Model, Key> extends true
+              ? never
+              : Key
         : never]: GetModelField<Schema, Model, Key>;
 };
 

--- a/packages/orm/src/client/crud-types.ts
+++ b/packages/orm/src/client/crud-types.ts
@@ -23,6 +23,8 @@ import type {
     GetTypeDefs,
     ModelFieldIsOptional,
     NonRelationFields,
+    NonVirtualFields,
+    NonVirtualNonRelationFields,
     ProcedureDef,
     RelationFields,
     RelationFieldType,
@@ -281,7 +283,8 @@ export type WhereInput<
     ScalarOnly extends boolean = false,
     WithAggregations extends boolean = false,
 > = {
-    [Key in GetModelFields<Schema, Model> as ScalarOnly extends true
+    // Use NonVirtualFields to exclude virtual fields - they are computed at runtime and cannot be filtered in the database
+    [Key in NonVirtualFields<Schema, Model> as ScalarOnly extends true
         ? Key extends RelationFields<Schema, Model>
             ? never
             : Key
@@ -755,7 +758,8 @@ export type OrderBy<
     WithRelation extends boolean,
     WithAggregation extends boolean,
 > = {
-    [Key in NonRelationFields<Schema, Model>]?: ModelFieldIsOptional<Schema, Model, Key> extends true
+    // Use NonVirtualNonRelationFields to exclude virtual fields - they are computed at runtime and cannot be sorted in the database
+    [Key in NonVirtualNonRelationFields<Schema, Model>]?: ModelFieldIsOptional<Schema, Model, Key> extends true
         ?
               | SortOrder
               | {

--- a/packages/orm/src/client/crud-types.ts
+++ b/packages/orm/src/client/crud-types.ts
@@ -8,6 +8,7 @@ import type {
     FieldIsDelegateDiscriminator,
     FieldIsDelegateRelation,
     FieldIsRelation,
+    FieldIsVirtual,
     FieldType,
     ForeignKeyFields,
     GetEnum,
@@ -1591,7 +1592,7 @@ export type CountArgs<Schema extends SchemaDef, Model extends GetModels<Schema>>
 };
 
 type CountAggregateInput<Schema extends SchemaDef, Model extends GetModels<Schema>> = {
-    [Key in NonRelationFields<Schema, Model>]?: true;
+    [Key in NonVirtualNonRelationFields<Schema, Model>]?: true;
 } & { _all?: true };
 
 export type CountResult<Schema extends SchemaDef, _Model extends GetModels<Schema>, Args> = Args extends {
@@ -1678,7 +1679,9 @@ type MinMaxInput<Schema extends SchemaDef, Model extends GetModels<Schema>, Valu
         ? never
         : FieldIsRelation<Schema, Model, Key> extends true
           ? never
-          : Key]?: ValueType;
+          : FieldIsVirtual<Schema, Model, Key> extends true
+            ? never
+            : Key]?: ValueType;
 };
 
 export type AggregateResult<Schema extends SchemaDef, _Model extends GetModels<Schema>, Args> = (Args extends {
@@ -1755,7 +1758,7 @@ export type GroupByArgs<Schema extends SchemaDef, Model extends GetModels<Schema
     /**
      * Fields to group by
      */
-    by: NonRelationFields<Schema, Model> | NonEmptyArray<NonRelationFields<Schema, Model>>;
+    by: NonVirtualNonRelationFields<Schema, Model> | NonEmptyArray<NonVirtualNonRelationFields<Schema, Model>>;
 
     /**
      * Filter conditions for the grouped records

--- a/packages/orm/src/client/crud-types.ts
+++ b/packages/orm/src/client/crud-types.ts
@@ -973,7 +973,7 @@ type RelationFilter<
 
 //#region Field utils
 
-type MapModelFieldType<
+export type MapModelFieldType<
     Schema extends SchemaDef,
     Model extends GetModels<Schema>,
     Field extends GetModelFields<Schema, Model>,

--- a/packages/orm/src/client/crud-types.ts
+++ b/packages/orm/src/client/crud-types.ts
@@ -1359,7 +1359,7 @@ type UpdateScalarInput<
     Without extends string = never,
 > = Omit<
     {
-        [Key in NonRelationFields<Schema, Model> as FieldIsDelegateDiscriminator<Schema, Model, Key> extends true
+        [Key in NonVirtualNonRelationFields<Schema, Model> as FieldIsDelegateDiscriminator<Schema, Model, Key> extends true
             ? // discriminator fields cannot be assigned
               never
             : Key]?: ScalarUpdatePayload<Schema, Model, Key>;
@@ -1370,7 +1370,7 @@ type UpdateScalarInput<
 type ScalarUpdatePayload<
     Schema extends SchemaDef,
     Model extends GetModels<Schema>,
-    Field extends NonRelationFields<Schema, Model>,
+    Field extends NonVirtualNonRelationFields<Schema, Model>,
 > =
     | ScalarFieldMutationPayload<Schema, Model, Field>
     | (Field extends NumericFields<Schema, Model>

--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -1148,9 +1148,11 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             result = result.select((eb) => {
                 const jsonObject: Record<string, Expression<any>> = {};
                 for (const field of Object.keys(subModel.fields)) {
+                    const fieldDef = subModel.fields[field];
                     if (
                         isRelationField(this.schema, subModel.name, field) ||
-                        isInheritedField(this.schema, subModel.name, field)
+                        isInheritedField(this.schema, subModel.name, field) ||
+                        fieldDef?.virtual
                     ) {
                         continue;
                     }

--- a/packages/orm/src/client/crud/dialects/base-dialect.ts
+++ b/packages/orm/src/client/crud/dialects/base-dialect.ts
@@ -1133,6 +1133,11 @@ export abstract class BaseCrudDialect<Schema extends SchemaDef> {
             if (this.shouldOmitField(omit, model, field)) {
                 continue;
             }
+            // virtual fields don't exist in the database, skip them
+            const fieldDef = modelDef.fields[field];
+            if (fieldDef?.virtual) {
+                continue;
+            }
             result = this.buildSelectField(result, model, modelAlias, field);
         }
 

--- a/packages/orm/src/client/crud/dialects/sqlite.ts
+++ b/packages/orm/src/client/crud/dialects/sqlite.ts
@@ -253,7 +253,7 @@ export class SqliteCrudDialect<Schema extends SchemaDef> extends BaseCrudDialect
                 const omit = typeof payload === 'object' ? payload.omit : undefined;
                 objArgs.push(
                     ...Object.entries(relationModelDef.fields)
-                        .filter(([, value]) => !value.relation)
+                        .filter(([, value]) => !value.relation && !value.virtual)
                         .filter(([name]) => !this.shouldOmitField(omit, relationModel, name))
                         .map(([field]) => [sql.lit(field), this.fieldRef(relationModel, field, subQueryName, false)])
                         .flatMap((v) => v),
@@ -283,6 +283,8 @@ export class SqliteCrudDialect<Schema extends SchemaDef> extends BaseCrudDialect
                                         value,
                                     );
                                     return [sql.lit(field), subJson];
+                                } else if (fieldDef.virtual) {
+                                    return null;
                                 } else {
                                     return [
                                         sql.lit(field),
@@ -291,6 +293,7 @@ export class SqliteCrudDialect<Schema extends SchemaDef> extends BaseCrudDialect
                                 }
                             }
                         })
+                        .filter((v) => v !== null)
                         .flatMap((v) => v),
                 );
             }

--- a/packages/orm/src/client/crud/operations/base.ts
+++ b/packages/orm/src/client/crud/operations/base.ts
@@ -2555,6 +2555,9 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
         const computedFields = Object.values(modelDef.fields)
             .filter((f) => f.computed)
             .map((f) => f.name);
+        const virtualFields = Object.values(modelDef.fields)
+            .filter((f) => f.virtual)
+            .map((f) => f.name);
 
         const allFieldsSelected: string[] = [];
 
@@ -2574,8 +2577,12 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
             );
         }
 
-        if (allFieldsSelected.some((f) => relationFields.includes(f) || computedFields.includes(f))) {
-            // relation or computed field selected, need read back
+        if (
+            allFieldsSelected.some(
+                (f) => relationFields.includes(f) || computedFields.includes(f) || virtualFields.includes(f),
+            )
+        ) {
+            // relation, computed, or virtual field selected - need read back
             return { needReadBack: true, selectedFields: undefined };
         } else {
             return { needReadBack: false, selectedFields: allFieldsSelected };

--- a/packages/orm/src/client/crud/operations/base.ts
+++ b/packages/orm/src/client/crud/operations/base.ts
@@ -1306,9 +1306,10 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
                     // collect id field/values from the original filter
                     const idFields = requireIdFields(this.schema, model);
                     const filterIdValues: any = {};
+                    const whereRecord = combinedWhere as Record<string, unknown>;
                     for (const key of idFields) {
-                        if (combinedWhere[key] !== undefined && typeof combinedWhere[key] !== 'object') {
-                            filterIdValues[key] = combinedWhere[key];
+                        if (whereRecord[key] !== undefined && typeof whereRecord[key] !== 'object') {
+                            filterIdValues[key] = whereRecord[key];
                         }
                     }
 

--- a/packages/orm/src/client/crud/operations/base.ts
+++ b/packages/orm/src/client/crud/operations/base.ts
@@ -363,7 +363,7 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
         }
 
         if (!hasNonVirtualField) {
-            throw createInternalError('Cannot select only virtual fields', model);
+            throw createInvalidInputError('Cannot select only virtual fields', model);
         }
 
         return result;

--- a/packages/orm/src/client/crud/operations/base.ts
+++ b/packages/orm/src/client/crud/operations/base.ts
@@ -335,8 +335,10 @@ export abstract class BaseOperationHandler<Schema extends SchemaDef> {
 
             const fieldDef = this.requireField(model, field);
             if (!fieldDef.relation) {
-                // scalar field
-                result = this.dialect.buildSelectField(result, model, parentAlias, field);
+                // scalar field - skip virtual fields as they're computed at runtime
+                if (!fieldDef.virtual) {
+                    result = this.dialect.buildSelectField(result, model, parentAlias, field);
+                }
             } else {
                 if (!fieldDef.array && !fieldDef.optional && payload.where) {
                     throw createInternalError(`Field "${field}" does not support filtering`, model);

--- a/packages/orm/src/client/crud/validator/index.ts
+++ b/packages/orm/src/client/crud/validator/index.ts
@@ -1236,7 +1236,7 @@ export class InputValidator<Schema extends SchemaDef> {
                 return;
             }
             const fieldDef = requireField(this.schema, model, field);
-            if (fieldDef.computed) {
+            if (fieldDef.computed || fieldDef.virtual) {
                 return;
             }
 

--- a/packages/orm/src/client/crud/validator/index.ts
+++ b/packages/orm/src/client/crud/validator/index.ts
@@ -1557,6 +1557,9 @@ export class InputValidator<Schema extends SchemaDef> {
                 return;
             }
             const fieldDef = requireField(this.schema, model, field);
+            if (fieldDef.computed || fieldDef.virtual) {
+                return;
+            }
 
             if (fieldDef.relation) {
                 if (withoutRelationFields) {

--- a/packages/orm/src/client/helpers/schema-db-pusher.ts
+++ b/packages/orm/src/client/helpers/schema-db-pusher.ts
@@ -115,7 +115,7 @@ export class SchemaDbPusher<Schema extends SchemaDef> {
 
             if (fieldDef.relation) {
                 table = this.addForeignKeyConstraint(table, modelDef.name, fieldName, fieldDef);
-            } else if (!this.isComputedField(fieldDef)) {
+            } else if (!this.isComputedField(fieldDef) && !this.isVirtualField(fieldDef)) {
                 table = this.createModelField(table, fieldDef, modelDef);
             }
         }
@@ -173,6 +173,10 @@ export class SchemaDbPusher<Schema extends SchemaDef> {
 
     private isComputedField(fieldDef: FieldDef) {
         return fieldDef.attributes?.some((a) => a.name === '@computed');
+    }
+
+    private isVirtualField(fieldDef: FieldDef) {
+        return fieldDef.attributes?.some((a) => a.name === '@virtual');
     }
 
     private addPrimaryKeyConstraint(table: CreateTableBuilder<string, any>, modelDef: ModelDef) {

--- a/packages/orm/src/client/options.ts
+++ b/packages/orm/src/client/options.ts
@@ -159,7 +159,7 @@ export type VirtualFieldContext<Schema extends SchemaDef> = {
  */
 export type VirtualFieldFunction<Schema extends SchemaDef = SchemaDef> = (
     context: VirtualFieldContext<Schema>,
-) => unknown | Promise<unknown>;
+) => Promise<unknown> | unknown;
 
 export type VirtualFieldsOptions<Schema extends SchemaDef> = {
     [Model in GetModels<Schema> as 'virtualFields' extends keyof GetModel<Schema, Model> ? Model : never]: {

--- a/packages/orm/src/client/options.ts
+++ b/packages/orm/src/client/options.ts
@@ -1,7 +1,7 @@
 import type { Dialect, Expression, ExpressionBuilder, KyselyConfig } from 'kysely';
 import type { GetModel, GetModelFields, GetModels, ProcedureDef, ScalarFields, SchemaDef } from '../schema';
 import type { PrependParameter } from '../utils/type-utils';
-import type { AuthType, ClientContract, CRUD_EXT } from './contract';
+import type { ClientContract, CRUD_EXT } from './contract';
 import type { GetProcedureNames, ProcedureHandlerFunc } from './crud-types';
 import type { BaseCrudDialect } from './crud/dialects/base-dialect';
 import type { AnyPlugin } from './plugin';
@@ -144,16 +144,20 @@ export type HasComputedFields<Schema extends SchemaDef> =
  */
 export type VirtualFieldContext<Schema extends SchemaDef> = {
     /**
-     * The current authenticated user, if set via `$setAuth()`.
+     * The database row data (only contains fields that were selected in the query).
      */
-    auth: AuthType<Schema> | undefined;
+    row: Record<string, unknown>;
+
+    /**
+     * The ZenStack client instance.
+     */
+    client: ClientContract<Schema>;
 };
 
 /**
  * Function that computes a virtual field value at runtime.
  */
 export type VirtualFieldFunction<Schema extends SchemaDef = SchemaDef> = (
-    row: Record<string, unknown>,
     context: VirtualFieldContext<Schema>,
 ) => unknown | Promise<unknown>;
 

--- a/packages/orm/src/client/result-processor.ts
+++ b/packages/orm/src/client/result-processor.ts
@@ -141,6 +141,7 @@ export class ResultProcessor<Schema extends SchemaDef> {
 
         const virtualFieldNames = Object.keys(modelDef.virtualFields);
         const selectClause = args?.select;
+        const omitClause = args?.omit;
 
         // Build the context once for all virtual fields
         const context: VirtualFieldContext<Schema> = { auth };
@@ -149,6 +150,11 @@ export class ResultProcessor<Schema extends SchemaDef> {
             virtualFieldNames.map(async (fieldName) => {
                 // Skip if select clause exists and doesn't include this virtual field
                 if (selectClause && !selectClause[fieldName]) {
+                    return;
+                }
+
+                // Skip if omit clause includes this virtual field
+                if (omitClause?.[fieldName]) {
                     return;
                 }
 

--- a/packages/orm/src/client/result-processor.ts
+++ b/packages/orm/src/client/result-processor.ts
@@ -188,10 +188,7 @@ export class ResultProcessor<Schema extends SchemaDef> {
                     return;
                 }
 
-                const virtualFn = modelVirtualFieldOptions[fieldName];
-                if (!virtualFn) {
-                    return;
-                }
+                const virtualFn = modelVirtualFieldOptions[fieldName]!;
                 data[fieldName] = await virtualFn(context);
             }),
         );

--- a/packages/orm/src/client/result-processor.ts
+++ b/packages/orm/src/client/result-processor.ts
@@ -188,7 +188,10 @@ export class ResultProcessor<Schema extends SchemaDef> {
                     return;
                 }
 
-                const virtualFn = modelVirtualFieldOptions[fieldName]!;
+                const virtualFn = modelVirtualFieldOptions[fieldName];
+                if (!virtualFn) {
+                    return;
+                }
                 data[fieldName] = await virtualFn(context);
             }),
         );

--- a/packages/orm/src/client/result-processor.ts
+++ b/packages/orm/src/client/result-processor.ts
@@ -113,6 +113,9 @@ export class ResultProcessor<Schema extends SchemaDef> {
         }
     }
 
+    /**
+     * Extracts relation-specific args (select/omit/include) for nested processing.
+     * */
     private getRelationArgs(args: any, relationField: string): any {
         if (!args) {
             return undefined;
@@ -146,6 +149,9 @@ export class ResultProcessor<Schema extends SchemaDef> {
         return this.doProcessResult(relationData, fieldDef.type as GetModels<Schema>, args, auth);
     }
 
+    /**
+     * Computes virtual fields at runtime using functions from client options.
+     * */
     private async applyVirtualFields(data: any, model: GetModels<Schema>, args?: any, auth?: AuthType<Schema>) {
         if (!data || typeof data !== 'object') {
             return;

--- a/packages/orm/src/client/result-processor.ts
+++ b/packages/orm/src/client/result-processor.ts
@@ -18,14 +18,14 @@ export class ResultProcessor<Schema extends SchemaDef> {
         this.virtualFieldsOptions = (options as any).virtualFields;
     }
 
-    async processResult(data: any, model: GetModels<Schema>, args?: any, client?: ClientContract<Schema>) {
+    async processResult(data: any, model: GetModels<Schema>, args: any, client: ClientContract<Schema>) {
         const result = await this.doProcessResult(data, model, args, client);
         // deal with correcting the reversed order due to negative take
         this.fixReversedResult(result, model, args);
         return result;
     }
 
-    private async doProcessResult(data: any, model: GetModels<Schema>, args?: any, client?: ClientContract<Schema>) {
+    private async doProcessResult(data: any, model: GetModels<Schema>, args: any, client: ClientContract<Schema>) {
         if (Array.isArray(data)) {
             await Promise.all(
                 data.map(async (row, i) => {
@@ -38,7 +38,7 @@ export class ResultProcessor<Schema extends SchemaDef> {
         }
     }
 
-    private async processRow(data: any, model: GetModels<Schema>, args?: any, client?: ClientContract<Schema>) {
+    private async processRow(data: any, model: GetModels<Schema>, args: any, client: ClientContract<Schema>) {
         if (!data || typeof data !== 'object') {
             return data;
         }
@@ -136,7 +136,7 @@ export class ResultProcessor<Schema extends SchemaDef> {
         return undefined;
     }
 
-    private async processRelation(value: unknown, fieldDef: FieldDef, args?: any, client?: ClientContract<Schema>) {
+    private async processRelation(value: unknown, fieldDef: FieldDef, args: any, client: ClientContract<Schema>) {
         let relationData = value;
         if (typeof value === 'string') {
             // relation can be returned as a JSON string
@@ -152,7 +152,7 @@ export class ResultProcessor<Schema extends SchemaDef> {
     /**
      * Computes virtual fields at runtime using functions from client options.
      * */
-    private async applyVirtualFields(data: any, model: GetModels<Schema>, args?: any, client?: ClientContract<Schema>) {
+    private async applyVirtualFields(data: any, model: GetModels<Schema>, args: any, client: ClientContract<Schema>) {
         if (!data || typeof data !== 'object') {
             return;
         }
@@ -173,7 +173,7 @@ export class ResultProcessor<Schema extends SchemaDef> {
 
         const context: VirtualFieldContext<Schema> = {
             row: { ...data },
-            client: client!,
+            client,
         };
 
         await Promise.all(

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -32,6 +32,7 @@ export type ModelDef = {
     >;
     idFields: readonly string[];
     computedFields?: Record<string, Function>;
+    virtualFields?: Record<string, Function>;
     isDelegate?: boolean;
     subModels?: readonly string[];
     isView?: boolean;
@@ -77,6 +78,7 @@ export type FieldDef = {
     relation?: RelationInfo;
     foreignKeyFor?: readonly string[];
     computed?: boolean;
+    virtual?: boolean;
     originModel?: string;
     isDiscriminator?: boolean;
 };
@@ -205,7 +207,9 @@ export type ScalarFields<
             ? Key
             : FieldIsComputed<Schema, Model, Key> extends true
               ? never
-              : Key]: Key;
+              : FieldIsVirtual<Schema, Model, Key> extends true
+                ? never
+                : Key]: Key;
 };
 
 export type ForeignKeyFields<Schema extends SchemaDef, Model extends GetModels<Schema>> = keyof {
@@ -228,6 +232,20 @@ export type RelationFields<Schema extends SchemaDef, Model extends GetModels<Sch
     [Key in GetModelFields<Schema, Model> as GetModelField<Schema, Model, Key>['relation'] extends object
         ? Key
         : never]: Key;
+};
+
+export type NonVirtualFields<Schema extends SchemaDef, Model extends GetModels<Schema>> = keyof {
+    [Key in GetModelFields<Schema, Model> as GetModelField<Schema, Model, Key>['virtual'] extends true
+        ? never
+        : Key]: Key;
+};
+
+export type NonVirtualNonRelationFields<Schema extends SchemaDef, Model extends GetModels<Schema>> = keyof {
+    [Key in GetModelFields<Schema, Model> as GetModelField<Schema, Model, Key>['virtual'] extends true
+        ? never
+        : GetModelField<Schema, Model, Key>['relation'] extends object
+          ? never
+          : Key]: Key;
 };
 
 export type FieldType<
@@ -280,6 +298,12 @@ export type FieldIsComputed<
     Model extends GetModels<Schema>,
     Field extends GetModelFields<Schema, Model>,
 > = GetModelField<Schema, Model, Field>['computed'] extends true ? true : false;
+
+export type FieldIsVirtual<
+    Schema extends SchemaDef,
+    Model extends GetModels<Schema>,
+    Field extends GetModelFields<Schema, Model>,
+> = GetModelField<Schema, Model, Field>['virtual'] extends true ? true : false;
 
 export type FieldHasDefault<
     Schema extends SchemaDef,

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -313,6 +313,14 @@ export type FieldIsVirtual<
     Field extends GetModelFields<Schema, Model>,
 > = GetModelField<Schema, Model, Field>['virtual'] extends true | VirtualFieldInfo ? true : false;
 
+export type GetVirtualFieldDependencies<
+    Schema extends SchemaDef,
+    Model extends GetModels<Schema>,
+    Field extends GetModelFields<Schema, Model>,
+> = GetModelField<Schema, Model, Field>['virtual'] extends { dependencies: readonly (infer D)[] }
+    ? D & GetModelFields<Schema, Model>
+    : never;
+
 export type FieldHasDefault<
     Schema extends SchemaDef,
     Model extends GetModels<Schema>,

--- a/packages/schema/src/schema.ts
+++ b/packages/schema/src/schema.ts
@@ -64,6 +64,10 @@ export type UpdatedAtInfo = {
     ignore?: readonly string[];
 };
 
+export type VirtualFieldInfo = {
+    dependencies?: readonly string[];
+};
+
 export type FieldDef = {
     name: string;
     type: string;
@@ -78,7 +82,7 @@ export type FieldDef = {
     relation?: RelationInfo;
     foreignKeyFor?: readonly string[];
     computed?: boolean;
-    virtual?: boolean;
+    virtual?: boolean | VirtualFieldInfo;
     originModel?: string;
     isDiscriminator?: boolean;
 };
@@ -235,13 +239,17 @@ export type RelationFields<Schema extends SchemaDef, Model extends GetModels<Sch
 };
 
 export type NonVirtualFields<Schema extends SchemaDef, Model extends GetModels<Schema>> = keyof {
-    [Key in GetModelFields<Schema, Model> as GetModelField<Schema, Model, Key>['virtual'] extends true
+    [Key in GetModelFields<Schema, Model> as GetModelField<Schema, Model, Key>['virtual'] extends
+        | true
+        | VirtualFieldInfo
         ? never
         : Key]: Key;
 };
 
 export type NonVirtualNonRelationFields<Schema extends SchemaDef, Model extends GetModels<Schema>> = keyof {
-    [Key in GetModelFields<Schema, Model> as GetModelField<Schema, Model, Key>['virtual'] extends true
+    [Key in GetModelFields<Schema, Model> as GetModelField<Schema, Model, Key>['virtual'] extends
+        | true
+        | VirtualFieldInfo
         ? never
         : GetModelField<Schema, Model, Key>['relation'] extends object
           ? never
@@ -303,7 +311,7 @@ export type FieldIsVirtual<
     Schema extends SchemaDef,
     Model extends GetModels<Schema>,
     Field extends GetModelFields<Schema, Model>,
-> = GetModelField<Schema, Model, Field>['virtual'] extends true ? true : false;
+> = GetModelField<Schema, Model, Field>['virtual'] extends true | VirtualFieldInfo ? true : false;
 
 export type FieldHasDefault<
     Schema extends SchemaDef,

--- a/packages/sdk/src/prisma/prisma-schema-generator.ts
+++ b/packages/sdk/src/prisma/prisma-schema-generator.ts
@@ -187,8 +187,8 @@ export class PrismaSchemaGenerator {
         const model = decl.isView ? prisma.addView(decl.name) : prisma.addModel(decl.name);
         const allFields = getAllFields(decl, true);
         for (const field of allFields) {
-            if (ModelUtils.hasAttribute(field, '@computed')) {
-                continue; // skip computed fields
+            if (ModelUtils.hasAttribute(field, '@computed') || ModelUtils.hasAttribute(field, '@virtual')) {
+                continue; // skip computed and virtual fields
             }
             // exclude non-id fields inherited from delegate
             if (ModelUtils.isIdField(field, decl) || !this.isInheritedFromDelegate(field, decl)) {

--- a/packages/sdk/src/ts-schema-generator.ts
+++ b/packages/sdk/src/ts-schema-generator.ts
@@ -427,6 +427,14 @@ export class TsSchemaGenerator {
             );
         }
 
+        const virtualFields = dm.fields.filter((f) => hasAttribute(f, '@virtual'));
+
+        if (virtualFields.length > 0) {
+            fields.push(
+                ts.factory.createPropertyAssignment('virtualFields', this.createVirtualFieldsObject(virtualFields)),
+            );
+        }
+
         return ts.factory.createObjectLiteralExpression(fields, true);
     }
 
@@ -511,6 +519,52 @@ export class TsSchemaGenerator {
                             ts.factory.createThrowStatement(
                                 ts.factory.createNewExpression(ts.factory.createIdentifier('Error'), undefined, [
                                     ts.factory.createStringLiteral('This is a stub for computed field'),
+                                ]),
+                            ),
+                        ],
+                        true,
+                    ),
+                ),
+            ),
+            true,
+        );
+    }
+
+    private createVirtualFieldsObject(fields: DataField[]) {
+        return ts.factory.createObjectLiteralExpression(
+            fields.map((field) =>
+                ts.factory.createMethodDeclaration(
+                    undefined,
+                    undefined,
+                    field.name,
+                    undefined,
+                    undefined,
+                    [
+                        // parameter: `_row: Record<string, unknown>`
+                        ts.factory.createParameterDeclaration(
+                            undefined,
+                            undefined,
+                            '_row',
+                            undefined,
+                            ts.factory.createTypeReferenceNode('Record', [
+                                ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                                ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
+                            ]),
+                            undefined,
+                        ),
+                    ],
+                    // Return type: T | Promise<T>
+                    ts.factory.createUnionTypeNode([
+                        ts.factory.createTypeReferenceNode(this.mapFieldTypeToTSType(field.type)),
+                        ts.factory.createTypeReferenceNode('Promise', [
+                            ts.factory.createTypeReferenceNode(this.mapFieldTypeToTSType(field.type)),
+                        ]),
+                    ]),
+                    ts.factory.createBlock(
+                        [
+                            ts.factory.createThrowStatement(
+                                ts.factory.createNewExpression(ts.factory.createIdentifier('Error'), undefined, [
+                                    ts.factory.createStringLiteral('This is a stub for virtual field'),
                                 ]),
                             ),
                         ],
@@ -682,6 +736,10 @@ export class TsSchemaGenerator {
 
         if (hasAttribute(field, '@computed')) {
             objectFields.push(ts.factory.createPropertyAssignment('computed', ts.factory.createTrue()));
+        }
+
+        if (hasAttribute(field, '@virtual')) {
+            objectFields.push(ts.factory.createPropertyAssignment('virtual', ts.factory.createTrue()));
         }
 
         if (isDataModel(field.type.reference?.ref)) {

--- a/packages/sdk/src/ts-schema-generator.ts
+++ b/packages/sdk/src/ts-schema-generator.ts
@@ -738,8 +738,28 @@ export class TsSchemaGenerator {
             objectFields.push(ts.factory.createPropertyAssignment('computed', ts.factory.createTrue()));
         }
 
-        if (hasAttribute(field, '@virtual')) {
-            objectFields.push(ts.factory.createPropertyAssignment('virtual', ts.factory.createTrue()));
+        const virtualAttrib = getAttribute(field, '@virtual') as DataFieldAttribute | undefined;
+        if (virtualAttrib) {
+            const depsArg = virtualAttrib.args.find((arg) => arg.$resolvedParam?.name === 'dependencies');
+            if (depsArg) {
+                objectFields.push(
+                    ts.factory.createPropertyAssignment(
+                        'virtual',
+                        ts.factory.createObjectLiteralExpression([
+                            ts.factory.createPropertyAssignment(
+                                'dependencies',
+                                ts.factory.createArrayLiteralExpression(
+                                    (depsArg.value as ArrayExpr).items.map((item) =>
+                                        ts.factory.createStringLiteral((item as ReferenceExpr).target.$refText),
+                                    ),
+                                ),
+                            ),
+                        ]),
+                    ),
+                );
+            } else {
+                objectFields.push(ts.factory.createPropertyAssignment('virtual', ts.factory.createTrue()));
+            }
         }
 
         if (isDataModel(field.type.reference?.ref)) {

--- a/tests/e2e/orm/client-api/virtual-fields.test.ts
+++ b/tests/e2e/orm/client-api/virtual-fields.test.ts
@@ -1,0 +1,503 @@
+import { createTestClient } from '@zenstackhq/testtools';
+import { describe, expect, it } from 'vitest';
+
+describe('Virtual fields tests', () => {
+    it('works with sync virtual fields', async () => {
+        const db = await createTestClient(
+            `
+model User {
+    id Int @id @default(autoincrement())
+    firstName String
+    lastName String
+    fullName String @virtual
+}
+`,
+            {
+                virtualFields: {
+                    User: {
+                        fullName: (row: any) => `${row.firstName} ${row.lastName}`,
+                    },
+                },
+            } as any,
+        );
+
+        await expect(
+            db.user.create({
+                data: { id: 1, firstName: 'Alex', lastName: 'Smith' },
+            }),
+        ).resolves.toMatchObject({
+            fullName: 'Alex Smith',
+        });
+
+        await expect(
+            db.user.findUnique({
+                where: { id: 1 },
+            }),
+        ).resolves.toMatchObject({
+            fullName: 'Alex Smith',
+        });
+
+        await expect(
+            db.user.findMany(),
+        ).resolves.toEqual([
+            expect.objectContaining({
+                fullName: 'Alex Smith',
+            }),
+        ]);
+    });
+
+    it('works with async virtual fields', async () => {
+        const db = await createTestClient(
+            `
+model Blob {
+    id Int @id @default(autoincrement())
+    blobName String
+    sasUrl String @virtual
+}
+`,
+            {
+                virtualFields: {
+                    Blob: {
+                        sasUrl: async (row: any) => {
+                            // Simulate async operation (e.g., generating SAS token)
+                            await new Promise((resolve) => setTimeout(resolve, 10));
+                            return `https://storage.example.com/${row.blobName}?sas=token123`;
+                        },
+                    },
+                },
+            } as any,
+        );
+
+        await expect(
+            db.blob.create({
+                data: { id: 1, blobName: 'my-file.pdf' },
+            }),
+        ).resolves.toMatchObject({
+            sasUrl: 'https://storage.example.com/my-file.pdf?sas=token123',
+        });
+    });
+
+    it('respects select clause - includes virtual field when selected', async () => {
+        const db = await createTestClient(
+            `
+model User {
+    id Int @id @default(autoincrement())
+    firstName String
+    lastName String
+    fullName String @virtual
+}
+`,
+            {
+                virtualFields: {
+                    User: {
+                        fullName: (row: any) => `${row.firstName} ${row.lastName}`,
+                    },
+                },
+            } as any,
+        );
+
+        await db.user.create({
+            data: { id: 1, firstName: 'Alex', lastName: 'Smith' },
+        });
+
+        // When selecting the virtual field explicitly, it should be computed
+        await expect(
+            db.user.findUnique({
+                where: { id: 1 },
+                select: { id: true, fullName: true },
+            }),
+        ).resolves.toMatchObject({
+            id: 1,
+            fullName: 'Alex Smith',
+        });
+    });
+
+    it('respects select clause - skips virtual field when not selected', async () => {
+        let virtualFieldCalled = false;
+
+        const db = await createTestClient(
+            `
+model User {
+    id Int @id @default(autoincrement())
+    firstName String
+    lastName String
+    fullName String @virtual
+}
+`,
+            {
+                virtualFields: {
+                    User: {
+                        fullName: (row: any) => {
+                            virtualFieldCalled = true;
+                            return `${row.firstName} ${row.lastName}`;
+                        },
+                    },
+                },
+            } as any,
+        );
+
+        await db.user.create({
+            data: { id: 1, firstName: 'Alex', lastName: 'Smith' },
+        });
+
+        virtualFieldCalled = false;
+
+        // When NOT selecting the virtual field, it should NOT be computed
+        const result = await db.user.findUnique({
+            where: { id: 1 },
+            select: { id: true, firstName: true },
+        });
+
+        expect(result).toMatchObject({
+            id: 1,
+            firstName: 'Alex',
+        });
+        expect(result).not.toHaveProperty('fullName');
+        expect(virtualFieldCalled).toBe(false);
+    });
+
+    it('works with optional virtual fields', async () => {
+        const db = await createTestClient(
+            `
+model User {
+    id Int @id @default(autoincrement())
+    name String
+    computedValue String? @virtual
+}
+`,
+            {
+                virtualFields: {
+                    User: {
+                        computedValue: () => null,
+                    },
+                },
+            } as any,
+        );
+
+        await expect(
+            db.user.create({
+                data: { id: 1, name: 'Alex' },
+            }),
+        ).resolves.toMatchObject({
+            computedValue: null,
+        });
+    });
+
+    it('works with relations - virtual field in nested result', async () => {
+        const db = await createTestClient(
+            `
+model User {
+    id Int @id @default(autoincrement())
+    name String
+    displayName String @virtual
+    posts Post[]
+}
+
+model Post {
+    id Int @id @default(autoincrement())
+    title String
+    author User @relation(fields: [authorId], references: [id])
+    authorId Int
+}
+`,
+            {
+                virtualFields: {
+                    User: {
+                        displayName: (row: any) => `@${row.name}`,
+                    },
+                },
+            } as any,
+        );
+
+        await db.user.create({
+            data: { id: 1, name: 'alex', posts: { create: { title: 'Post1' } } },
+        });
+
+        await expect(
+            db.post.findFirst({
+                include: { author: true },
+            }),
+        ).resolves.toMatchObject({
+            author: expect.objectContaining({ displayName: '@alex' }),
+        });
+    });
+
+    it('is typed correctly for non-optional fields', async () => {
+        await createTestClient(
+            `
+model User {
+    id Int @id @default(autoincrement())
+    name String
+    displayName String @virtual
+}
+`,
+            {
+                extraSourceFiles: {
+                    main: `
+import { ZenStackClient } from '@zenstackhq/orm';
+import { schema } from './schema';
+
+async function main() {
+    const client = new ZenStackClient(schema, {
+        dialect: {} as any,
+        virtualFields: {
+            User: {
+                displayName: (row) => \`@\${row.name}\`,
+            },
+        }
+    });
+
+    const user = await client.user.create({
+        data: { id: 1, name: 'Alex' }
+    });
+    console.log(user.displayName);
+    // @ts-expect-error - virtual field should not be nullable
+    user.displayName = null;
+}
+
+main();
+`,
+                },
+            },
+        );
+    });
+
+    it('virtual fields are excluded from where and orderBy types', async () => {
+        await createTestClient(
+            `
+model Post {
+    id Int @id @default(autoincrement())
+    title String
+    canEdit Boolean @virtual
+}
+`,
+            {
+                extraSourceFiles: {
+                    main: `
+import { ZenStackClient } from '@zenstackhq/orm';
+import { schema } from './schema';
+
+async function main() {
+    const client = new ZenStackClient(schema, {
+        dialect: {} as any,
+        virtualFields: {
+            Post: {
+                canEdit: () => true,
+            },
+        }
+    });
+
+    // Virtual fields should be in the result type
+    const post = await client.post.findFirst();
+    const canEdit: boolean | undefined = post?.canEdit;
+
+    // @ts-expect-error - virtual field should not be allowed in where
+    await client.post.findMany({ where: { canEdit: true } });
+
+    // @ts-expect-error - virtual field should not be allowed in orderBy
+    await client.post.findMany({ orderBy: { canEdit: 'asc' } });
+
+    // Regular fields should still work
+    await client.post.findMany({ where: { title: 'test' } });
+    await client.post.findMany({ orderBy: { title: 'asc' } });
+}
+
+main();
+`,
+                },
+            },
+        );
+    });
+
+    it('receives auth context in virtual field function', async () => {
+        const db = await createTestClient(
+            `
+model User {
+    id Int @id @default(autoincrement())
+    name String
+}
+
+model Post {
+    id Int @id @default(autoincrement())
+    title String
+    authorId Int
+    canEdit Boolean @virtual
+}
+`,
+            {
+                virtualFields: {
+                    Post: {
+                        canEdit: (row: any, { auth }: any) => {
+                            // User can edit if they are the author
+                            return auth?.id === row.authorId;
+                        },
+                    },
+                },
+            } as any,
+        );
+
+        // Create a post
+        await db.post.create({
+            data: { id: 1, title: 'My Post', authorId: 1 },
+        });
+
+        // Without auth, canEdit should be false
+        const postWithoutAuth = await db.post.findUnique({ where: { id: 1 } });
+        expect(postWithoutAuth?.canEdit).toBe(false);
+
+        // With auth as the author, canEdit should be true
+        const dbWithAuth = db.$setAuth({ id: 1 });
+        const postWithAuth = await dbWithAuth.post.findUnique({ where: { id: 1 } });
+        expect(postWithAuth?.canEdit).toBe(true);
+
+        // With auth as different user, canEdit should be false
+        const dbWithOtherAuth = db.$setAuth({ id: 2 });
+        const postWithOtherAuth = await dbWithOtherAuth.post.findUnique({ where: { id: 1 } });
+        expect(postWithOtherAuth?.canEdit).toBe(false);
+    });
+
+    it('auth context works with nested relations', async () => {
+        const db = await createTestClient(
+            `
+model User {
+    id Int @id @default(autoincrement())
+    name String
+    posts Post[]
+}
+
+model Post {
+    id Int @id @default(autoincrement())
+    title String
+    author User @relation(fields: [authorId], references: [id])
+    authorId Int
+    isOwnPost Boolean @virtual
+}
+`,
+            {
+                virtualFields: {
+                    Post: {
+                        isOwnPost: (row: any, { auth }: any) => auth?.id === row.authorId,
+                    },
+                },
+            } as any,
+        );
+
+        await db.user.create({
+            data: {
+                id: 1,
+                name: 'Alex',
+                posts: { create: { id: 1, title: 'Post1' } },
+            },
+        });
+
+        // Query posts through user relation with auth set
+        const dbWithAuth = db.$setAuth({ id: 1 });
+        const user = await dbWithAuth.user.findUnique({
+            where: { id: 1 },
+            include: { posts: true },
+        });
+
+        expect(user?.posts[0]?.isOwnPost).toBe(true);
+
+        // With different auth
+        const dbWithOtherAuth = db.$setAuth({ id: 2 });
+        const userOther = await dbWithOtherAuth.user.findUnique({
+            where: { id: 1 },
+            include: { posts: true },
+        });
+
+        expect(userOther?.posts[0]?.isOwnPost).toBe(false);
+    });
+
+    it('works with relations and virtual fields on PostgreSQL (lateral join dialect)', async () => {
+        // This test specifically targets the lateral join dialect used by PostgreSQL
+        // to ensure virtual fields are properly excluded from SQL queries when
+        // including relations with default select (no explicit select clause)
+        const db = await createTestClient(
+            `
+model User {
+    id Int @id @default(autoincrement())
+    name String
+    displayName String @virtual
+    posts Post[]
+}
+
+model Post {
+    id Int @id @default(autoincrement())
+    title String
+    author User @relation(fields: [authorId], references: [id])
+    authorId Int
+}
+`,
+            {
+                provider: 'postgresql',
+                virtualFields: {
+                    User: {
+                        displayName: (row: any) => `@${row.name}`,
+                    },
+                },
+            } as any,
+        );
+
+        await db.user.create({
+            data: { id: 1, name: 'alex', posts: { create: { title: 'Post1' } } },
+        });
+
+        // Include relation with default select - this triggers buildRelationObjectArgs
+        // in the lateral join dialect which must properly exclude virtual fields
+        await expect(
+            db.post.findFirst({
+                include: { author: true },
+            }),
+        ).resolves.toMatchObject({
+            title: 'Post1',
+            author: expect.objectContaining({
+                name: 'alex',
+                displayName: '@alex',
+            }),
+        });
+    });
+
+    it('works with virtual fields in delegate sub-models', async () => {
+        // This test ensures virtual fields are properly excluded when building
+        // delegate descendant JSON objects in buildSelectAllFields
+        const db = await createTestClient(
+            `
+model Content {
+    id Int @id @default(autoincrement())
+    title String
+    contentType String
+    @@delegate(contentType)
+}
+
+model Post extends Content {
+    body String
+    preview String @virtual
+}
+`,
+            {
+                virtualFields: {
+                    Post: {
+                        preview: (row: any) => row.body?.substring(0, 50) ?? '',
+                    },
+                },
+            } as any,
+        );
+
+        await db.post.create({
+            data: { id: 1, title: 'My Post', body: 'This is the full body content of the post' },
+        });
+
+        // Query the base Content model - this triggers buildSelectAllFields which
+        // builds JSON for delegate descendants (Post) and must exclude virtual fields
+        await expect(
+            db.content.findFirst({
+                where: { id: 1 },
+            }),
+        ).resolves.toMatchObject({
+            title: 'My Post',
+            body: 'This is the full body content of the post',
+            preview: 'This is the full body content of the post',
+        });
+    });
+});

--- a/tests/e2e/orm/client-api/virtual-fields.test.ts
+++ b/tests/e2e/orm/client-api/virtual-fields.test.ts
@@ -331,9 +331,17 @@ async function main() {
     // @ts-expect-error - virtual field should not be allowed in orderBy
     await client.post.findMany({ orderBy: { canEdit: 'asc' } });
 
+    // @ts-expect-error - virtual field should not be allowed in create data
+    await client.post.create({ data: { title: 'test', canEdit: true } });
+
+    // @ts-expect-error - virtual field should not be allowed in update data
+    await client.post.update({ where: { id: 1 }, data: { canEdit: false } });
+
     // Regular fields should still work
     await client.post.findMany({ where: { title: 'test' } });
     await client.post.findMany({ orderBy: { title: 'asc' } });
+    await client.post.create({ data: { title: 'test' } });
+    await client.post.update({ where: { id: 1 }, data: { title: 'updated' } });
 }
 
 main();

--- a/tests/e2e/orm/client-api/virtual-fields.test.ts
+++ b/tests/e2e/orm/client-api/virtual-fields.test.ts
@@ -381,10 +381,16 @@ async function main() {
     // @ts-expect-error - virtual field should not be allowed in _max
     await client.post.aggregate({ _max: { computedScore: true } });
 
+    // @ts-expect-error - virtual field should not be allowed in _sum
+    await client.post.aggregate({ _sum: { computedScore: true } });
+
+    // @ts-expect-error - virtual field should not be allowed in _avg
+    await client.post.aggregate({ _avg: { computedScore: true } });
+
     // Regular fields should still work in all these operations
     await client.post.groupBy({ by: ['title'] });
     await client.post.count({ select: { title: true } });
-    await client.post.aggregate({ _min: { views: true }, _max: { views: true } });
+    await client.post.aggregate({ _min: { views: true }, _max: { views: true }, _sum: { views: true }, _avg: { views: true } });
 }
 
 main();


### PR DESCRIPTION
Adds support for `@virtual` fields that are computed at JavaScript runtime after query results are returned, complementing the existing `@computed`  fields that are calculated at the database level.

Discord ref: https://discord.com/channels/1035538056146595961/1468213504724045905

**Example**

```ts
// Schema
model User {
    id Int @id
    firstName String
    lastName String
    fullName String @virtual
}

// Client
const client = new ZenStackClient(schema, {
    dialect,
    virtualFields: {
        User: {
            fullName: ({row}) => `${row.firstName} ${row.lastName}`,
        },
    },
});
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime virtual fields: per-model virtual resolvers (sync/async) run with client/context and attach computed values to query results.

* **Behavior Changes**
  * Virtual fields are excluded from DB schema, selection filters, ordering, grouping and aggregates; selecting only virtuals triggers read-back behavior.
  * Result post-processing is now asynchronous and runs with request context; required dependencies for virtuals are fetched automatically.

* **Types & SDK**
  * Client options, generated schemas and model typings include virtual field metadata and typings.

* **Tests**
  * Comprehensive end-to-end tests for virtual fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->