### PR TITLE
chore: add warning for mismatched versions during `zen generate`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
             "skipFiles": ["<node_internals>/**"],
             "type": "node",
             "args": ["generate"],
-            "cwd": "${workspaceFolder}/samples/blog"
+            "cwd": "${workspaceFolder}/samples/orm"
         },
         {
             "name": "Debug with TSX",

--- a/packages/cli/src/actions/action-utils.ts
+++ b/packages/cli/src/actions/action-utils.ts
@@ -126,10 +126,10 @@ function findUp<Multiple extends boolean = false>(
     }
     const target = names.find((name) => fs.existsSync(path.join(cwd, name)));
     if (multiple === false && target) {
-        return path.join(cwd, target) as FindUpResult<Multiple>;
+        return path.resolve(cwd, target) as FindUpResult<Multiple>;
     }
     if (target) {
-        result.push(path.join(cwd, target));
+        result.push(path.resolve(cwd, target));
     }
     const up = path.resolve(cwd, '..');
     if (up === cwd) {
@@ -183,7 +183,7 @@ export async function getZenStackPackages(
         ),
     ).sort();
 
-    const require = createRequire(import.meta.url);
+    const require = createRequire(pkgJsonFile);
 
     const result = packages.map((pkg) => {
         try {

--- a/packages/cli/src/actions/generate.ts
+++ b/packages/cli/src/actions/generate.ts
@@ -336,7 +336,8 @@ async function checkForMismatchedPackages(projectPath: string) {
     }
 
     if (versions.size > 1) {
-        const message = 'WARNING: Multiple versions of ZenStack packages detected.\n\tThis will probably cause issues and break your types.';
+        const message =
+            'WARNING: Multiple versions of ZenStack packages detected.\n\tThis will probably cause issues and break your types.';
         const slashes = '/'.repeat(73);
         const latestVersion = semver.sort(Array.from(versions)).reverse()[0]!;
 
@@ -345,10 +346,9 @@ async function checkForMismatchedPackages(projectPath: string) {
             if (!version) continue;
 
             if (version === latestVersion) {
-                console.log(`\t${pkg.padEnd(20)}\t${colors.green(version)}`);
-            }
-            else {
-                console.log(`\t${pkg.padEnd(20)}\t${colors.yellow(version)}`);
+                console.log(`\t${pkg.padEnd(32)}\t${colors.green(version)}`);
+            } else {
+                console.log(`\t${pkg.padEnd(32)}\t${colors.yellow(version)}`);
             }
         }
         console.warn(`\n${colors.yellow(slashes)}`);

--- a/packages/cli/src/actions/generate.ts
+++ b/packages/cli/src/actions/generate.ts
@@ -340,7 +340,7 @@ async function checkForMismatchedPackages(projectPath: string) {
         const slashes = '/'.repeat(73);
         const latestVersion = semver.sort(Array.from(versions)).reverse()[0]!;
 
-        console.warn(colors.yellow(`${slashes}\n\t${message}\n`));
+        console.warn(colors.yellow(`${slashes}\n\n\t${message}\n`));
         for (const { pkg, version } of packages) {
             if (!version) continue;
 

--- a/packages/cli/src/actions/generate.ts
+++ b/packages/cli/src/actions/generate.ts
@@ -28,7 +28,11 @@ type Options = {
  * CLI action for generating code from schema
  */
 export async function run(options: Options) {
-    await checkForMismatchedPackages(process.cwd());
+    try {
+        await checkForMismatchedPackages(process.cwd());
+    } catch (err) {
+        console.warn(colors.yellow(`Failed to check for mismatched ZenStack packages: ${err}`));
+    }
     const model = await pureGenerate(options, false);
 
     if (options.watch) {

--- a/packages/cli/src/actions/generate.ts
+++ b/packages/cli/src/actions/generate.ts
@@ -12,7 +12,8 @@ import { watch } from 'chokidar';
 import ora, { type Ora } from 'ora';
 import { CliError } from '../cli-error';
 import * as corePlugins from '../plugins';
-import { getOutputPath, getSchemaFile, loadSchemaDocument } from './action-utils';
+import { getOutputPath, getSchemaFile, getZenStackPackages, loadSchemaDocument } from './action-utils';
+import semver from 'semver';
 
 type Options = {
     schema?: string;
@@ -27,6 +28,7 @@ type Options = {
  * CLI action for generating code from schema
  */
 export async function run(options: Options) {
+    await checkForMismatchedPackages(process.cwd());
     const model = await pureGenerate(options, false);
 
     if (options.watch) {
@@ -314,4 +316,41 @@ async function loadPluginModule(provider: string, basePath: string) {
         // plugin may not export a generator so we simply ignore the error here
         return undefined;
     }
+}
+
+async function checkForMismatchedPackages(projectPath: string) {
+    const packages = await getZenStackPackages(projectPath);
+    if (!packages) {
+        return false;
+    }
+
+    const versions = new Set<string>();
+    for (const { version } of packages) {
+        if (version) {
+            versions.add(version);
+        }
+    }
+
+    if (versions.size > 1) {
+        const message = 'WARNING: Multiple versions of ZenStack packages detected.\n\tThis will probably cause issues and break your types.';
+        const slashes = '/'.repeat(73);
+        const latestVersion = semver.sort(Array.from(versions)).reverse()[0]!;
+
+        console.warn(colors.yellow(`${slashes}\n\t${message}\n`));
+        for (const { pkg, version } of packages) {
+            if (!version) continue;
+
+            if (version === latestVersion) {
+                console.log(`\t${pkg.padEnd(20)}\t${colors.green(version)}`);
+            }
+            else {
+                console.log(`\t${pkg.padEnd(20)}\t${colors.yellow(version)}`);
+            }
+        }
+        console.warn(`\n${colors.yellow(slashes)}`);
+
+        return true;
+    }
+
+    return false;
 }

--- a/packages/cli/src/actions/generate.ts
+++ b/packages/cli/src/actions/generate.ts
@@ -320,7 +320,7 @@ async function loadPluginModule(provider: string, basePath: string) {
 
 async function checkForMismatchedPackages(projectPath: string) {
     const packages = await getZenStackPackages(projectPath);
-    if (!packages) {
+    if (!packages.length) {
         return false;
     }
 

--- a/packages/cli/src/actions/info.ts
+++ b/packages/cli/src/actions/info.ts
@@ -6,7 +6,7 @@ import { getZenStackPackages } from './action-utils';
  */
 export async function run(projectPath: string) {
     const packages = await getZenStackPackages(projectPath);
-    if (!packages) {
+    if (!packages.length) {
         console.error('Unable to locate package.json. Are you in a valid project directory?');
         return;
     }

--- a/packages/cli/src/actions/info.ts
+++ b/packages/cli/src/actions/info.ts
@@ -1,5 +1,5 @@
 import colors from 'colors';
-import path from 'node:path';
+import { getZenStackPackages } from './action-utils';
 
 /**
  * CLI action for getting information about installed ZenStack packages
@@ -23,49 +23,4 @@ export async function run(projectPath: string) {
     if (versions.size > 1) {
         console.warn(colors.yellow('WARNING: Multiple versions of Zenstack packages detected. This may cause issues.'));
     }
-}
-
-async function getZenStackPackages(projectPath: string): Promise<Array<{ pkg: string; version: string | undefined }>> {
-    let pkgJson: {
-        dependencies: Record<string, unknown>;
-        devDependencies: Record<string, unknown>;
-    };
-    const resolvedPath = path.resolve(projectPath);
-    try {
-        pkgJson = (
-            await import(path.join(resolvedPath, 'package.json'), {
-                with: { type: 'json' },
-            })
-        ).default;
-    } catch {
-        return [];
-    }
-
-    const packages = Array.from(
-        new Set(
-            [...Object.keys(pkgJson.dependencies ?? {}), ...Object.keys(pkgJson.devDependencies ?? {})].filter(
-                (p) => p.startsWith('@zenstackhq/') || p === 'zenstack',
-            ),
-        ),
-    ).sort();
-
-    const result = await Promise.all(
-        packages.map(async (pkg) => {
-            try {
-                const depPkgJson = (
-                    await import(`${pkg}/package.json`, {
-                        with: { type: 'json' },
-                    })
-                ).default;
-                if (depPkgJson.private) {
-                    return undefined;
-                }
-                return { pkg, version: depPkgJson.version as string };
-            } catch {
-                return { pkg, version: undefined };
-            }
-        }),
-    );
-
-    return result.filter((p) => !!p);
 }


### PR DESCRIPTION
Latest version highlighted in green, others yellow.
Closes zenstackhq/zenstack#2347 

<img width="671" height="261" alt="image" src="https://github.com/user-attachments/assets/ea809be4-b932-45e5-a223-14811ed7954c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a runtime check that warns when installed ZenStack packages have mismatched versions, listing packages and versions with clear highlighting.

* **Refactor**
  * Consolidates package discovery into a shared utility so CLI commands use a consistent package list and version resolution.

* **Chore**
  * Adjusts CLI debug working directory for development tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->