### PR TITLE
feat: separate enums from models

### DIFF
--- a/packages/sdk/src/ts-schema-generator.ts
+++ b/packages/sdk/src/ts-schema-generator.ts
@@ -1482,7 +1482,7 @@ export class TsSchemaGenerator {
         const printer = ts.createPrinter();
         const enumsOutputFile = path.join(options.outDir, 'enums.ts');
 
-        if (enumStatements.length > 0) {
+        if (enums.length > 0) {
             this.generateBannerComments(enumStatements);
 
             const enumsSourceFile = ts.createSourceFile(enumsOutputFile, '', ts.ScriptTarget.ESNext, false, ts.ScriptKind.TS);

--- a/packages/sdk/src/ts-schema-generator.ts
+++ b/packages/sdk/src/ts-schema-generator.ts
@@ -1483,6 +1483,8 @@ export class TsSchemaGenerator {
         const enumsOutputFile = path.join(options.outDir, 'enums.ts');
 
         if (enums.length > 0) {
+            this.generateBannerComments(enumStatements);
+
             const enumsSourceFile = ts.createSourceFile(enumsOutputFile, '', ts.ScriptTarget.ESNext, false, ts.ScriptKind.TS);
             const enumsResult = printer.printList(ts.ListFormat.MultiLine, ts.factory.createNodeArray(enumStatements), enumsSourceFile);
             fs.writeFileSync(enumsOutputFile, enumsResult);

--- a/packages/sdk/src/ts-schema-generator.ts
+++ b/packages/sdk/src/ts-schema-generator.ts
@@ -1504,7 +1504,9 @@ export class TsSchemaGenerator {
             ));
         }
         else {
-            fs.unlinkSync(enumsOutputFile);
+            if (fs.existsSync(enumsOutputFile)) {  
+                fs.unlinkSync(enumsOutputFile);  
+            }  
         }
 
         const modelsOutputFile = path.join(options.outDir, 'models.ts');

--- a/packages/sdk/src/ts-schema-generator.ts
+++ b/packages/sdk/src/ts-schema-generator.ts
@@ -1482,7 +1482,7 @@ export class TsSchemaGenerator {
         const printer = ts.createPrinter();
         const enumsOutputFile = path.join(options.outDir, 'enums.ts');
 
-        if (enums.length > 0) {
+        if (enumStatements.length > 0) {
             this.generateBannerComments(enumStatements);
 
             const enumsSourceFile = ts.createSourceFile(enumsOutputFile, '', ts.ScriptTarget.ESNext, false, ts.ScriptKind.TS);

--- a/packages/sdk/src/ts-schema-generator.ts
+++ b/packages/sdk/src/ts-schema-generator.ts
@@ -1347,7 +1347,7 @@ export class TsSchemaGenerator {
         statements.push(
             this.generateSchemaImport(
                 model,
-                true,
+                false,
                 true,
                 !!(options.lite || options.liteOnly),
                 options.importWithFileExtension,
@@ -1420,6 +1420,15 @@ export class TsSchemaGenerator {
 
         // generate: export const Enum = $schema.enums.Enum['values'];
         const enums = model.declarations.filter(isEnum);
+        const enumStatements: ts.Statement[] = [
+            this.generateSchemaImport(
+                model,
+                true,
+                false,
+                !!(options.lite || options.liteOnly),
+                options.importWithFileExtension,
+            )
+        ];
         for (const e of enums) {
             let enumDecl = ts.factory.createVariableStatement(
                 [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
@@ -1447,7 +1456,7 @@ export class TsSchemaGenerator {
             if (e.comments.length > 0) {
                 enumDecl = this.generateDocs(enumDecl, e);
             }
-            statements.push(enumDecl);
+            enumStatements.push(enumDecl);
 
             // generate: export type Enum = (typeof Enum)[keyof typeof Enum];
             let typeAlias = ts.factory.createTypeAliasDeclaration(
@@ -1465,17 +1474,41 @@ export class TsSchemaGenerator {
             if (e.comments.length > 0) {
                 typeAlias = this.generateDocs(typeAlias, e);
             }
-            statements.push(typeAlias);
+            enumStatements.push(typeAlias);
         }
 
         this.generateBannerComments(statements);
 
-        // write to file
-        const outputFile = path.join(options.outDir, 'models.ts');
-        const sourceFile = ts.createSourceFile(outputFile, '', ts.ScriptTarget.ESNext, false, ts.ScriptKind.TS);
         const printer = ts.createPrinter();
-        const result = printer.printList(ts.ListFormat.MultiLine, ts.factory.createNodeArray(statements), sourceFile);
-        fs.writeFileSync(outputFile, result);
+        const enumsOutputFile = path.join(options.outDir, 'enums.ts');
+
+        if (enums.length > 0) {
+            const enumsSourceFile = ts.createSourceFile(enumsOutputFile, '', ts.ScriptTarget.ESNext, false, ts.ScriptKind.TS);
+            const enumsResult = printer.printList(ts.ListFormat.MultiLine, ts.factory.createNodeArray(enumStatements), enumsSourceFile);
+            fs.writeFileSync(enumsOutputFile, enumsResult);
+
+            let exportFrom = './enums';
+            if (options.importWithFileExtension) {
+                exportFrom += options.importWithFileExtension.startsWith('.')
+                    ? options.importWithFileExtension
+                    : `.${options.importWithFileExtension}`;
+            }
+
+            statements.push(ts.factory.createExportDeclaration(
+                undefined,
+                false,
+                undefined,
+                ts.factory.createStringLiteral(exportFrom),
+            ));
+        }
+        else {
+            fs.unlinkSync(enumsOutputFile);
+        }
+
+        const modelsOutputFile = path.join(options.outDir, 'models.ts');
+        const modelsSourceFile = ts.createSourceFile(modelsOutputFile, '', ts.ScriptTarget.ESNext, false, ts.ScriptKind.TS);
+        const modelsResult = printer.printList(ts.ListFormat.MultiLine, ts.factory.createNodeArray(statements), modelsSourceFile);
+        fs.writeFileSync(modelsOutputFile, modelsResult);
     }
 
     private generateSchemaImport(


### PR DESCRIPTION
Enums are now generated to `enums.ts`
`models.ts` exports everything from `enums.ts` to maintain backwards compatibility.

Closes zenstackhq/zenstack#2345 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Generated enum declarations are emitted into a dedicated generated file and re-exported from the main generated models output for compatibility.
  * Enum output is produced only when enums exist and removed otherwise to avoid stale artifacts.
  * The generation order and export handling were adjusted for cleaner, more consistent generated model outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->