### PR TITLE
fix(introspection): preserve data validation attributes, enum ordering, and comments during db pull

### DIFF
--- a/packages/cli/src/actions/db.ts
+++ b/packages/cli/src/actions/db.ts
@@ -14,7 +14,7 @@ import {
 } from './action-utils';
 import { consolidateEnums, syncEnums, syncRelation, syncTable, type Relation } from './pull';
 import { providers as pullProviders } from './pull/provider';
-import { getDatasource, getDbName, getRelationFieldsKey, getRelationFkName } from './pull/utils';
+import { getDatasource, getDbName, getRelationFieldsKey, getRelationFkName, isDatabaseManagedAttribute } from './pull/utils';
 import type { DataSourceProviderType } from '@zenstackhq/schema';
 import { CliError } from '../cli-error';
 
@@ -461,12 +461,13 @@ async function runPull(options: PullOptions) {
                         }
                         return;
                     }
+
                     // Track deleted attributes (in original but not in new)
                     originalField.attributes
                         .filter(
                             (attr) =>
-                                !f.attributes.find((d) => d.decl.$refText === attr.decl.$refText) &&
-                                (['@relation'].includes(attr.decl.$refText) || attr.decl.$refText.startsWith('@db.')),
+                                !f.attributes.find((d) => d.decl.$refText === attr.decl.$refText) && 
+                                isDatabaseManagedAttribute(attr.decl.$refText),
                         )
                         .forEach((attr) => {
                             const field = attr.$container;
@@ -482,7 +483,7 @@ async function runPull(options: PullOptions) {
                         .filter(
                             (attr) =>
                                 !originalField.attributes.find((d) => d.decl.$refText === attr.decl.$refText) &&
-                                (['@relation'].includes(attr.decl.$refText) || attr.decl.$refText.startsWith('@db.')),
+                                isDatabaseManagedAttribute(attr.decl.$refText),
                         )
                         .forEach((attr) => {
                           // attach the new attribute to the original field

--- a/packages/cli/src/actions/pull/index.ts
+++ b/packages/cli/src/actions/pull/index.ts
@@ -533,12 +533,19 @@ export function syncRelation({
     sourceModel.fields.splice(firstSourceFieldId, 0, sourceFieldFactory.node); // Insert the relation field before the first FK scalar field
 
     const oppositeFieldPrefix = /[0-9]/g.test(targetModel.name.charAt(0)) ? '_' : '';
-    const { name: oppositeFieldName } = resolveNameCasing(
+    let { name: oppositeFieldName } = resolveNameCasing(
         options.fieldCasing,
         similarRelations > 0
             ? `${oppositeFieldPrefix}${lowerCaseFirst(sourceModel.name)}_${firstColumn}`
             : `${lowerCaseFirst(resolveNameCasing(options.fieldCasing, sourceModel.name).name)}${relation.references.type === 'many'? 's' : ''}`,
     );
+
+    if (targetModel.fields.find((f) => f.name === oppositeFieldName)) {
+        ({ name: oppositeFieldName } = resolveNameCasing(
+            options.fieldCasing,
+            `${lowerCaseFirst(sourceModel.name)}_${firstColumn}To${relation.references.table}_${relation.references.columns[0]}`,
+        ));
+    }
 
     const targetFieldFactory = new DataFieldFactory()
         .setContainer(targetModel)

--- a/packages/cli/src/actions/pull/index.ts
+++ b/packages/cli/src/actions/pull/index.ts
@@ -638,6 +638,15 @@ export function consolidateEnums({
         // Rename the kept enum to match the old shared name
         keepEnum.name = oldEnum.name;
 
+        // Replace keepEnum's attributes with those from the old enum so that
+        // any synthetic @@map added by syncEnums is removed and getDbName(keepEnum)
+        // reflects the consolidated name rather than the stale per-column name.
+        // Shallow-copy and re-parent so AST $container pointers reference keepEnum.
+        keepEnum.attributes = oldEnum.attributes.map((attr) => {
+            const copy = { ...attr, $container: keepEnum };
+            return copy;
+        });
+
         // Remove duplicate enums from newModel
         for (let i = 1; i < newEnumsGroup.length; i++) {
             const idx = newModel.declarations.indexOf(newEnumsGroup[i]!);

--- a/packages/cli/src/actions/pull/provider/mysql.ts
+++ b/packages/cli/src/actions/pull/provider/mysql.ts
@@ -266,6 +266,10 @@ export const mysql: IntrospectionProvider = {
                     return (ab) => ab.InvocationExpr.setFunction(getFunctionRef('uuid', services));
                 }
                 return (ab) => ab.StringLiteral.setValue(val);
+            case 'Json':
+                return (ab) => ab.StringLiteral.setValue(val);
+            case 'Bytes':
+                return (ab) => ab.StringLiteral.setValue(val);
         }
 
         // Handle function calls (e.g., uuid(), now())

--- a/packages/cli/src/actions/pull/provider/postgresql.ts
+++ b/packages/cli/src/actions/pull/provider/postgresql.ts
@@ -284,6 +284,16 @@ export const postgresql: IntrospectionProvider = {
                     return (ab) => ab.StringLiteral.setValue(val.slice(1, -1).replace(/''/g, "'"));
                 }
                 return (ab) => ab.StringLiteral.setValue(val);
+            case 'Json':
+                if (val.includes('::')) {
+                    return typeCastingConvert({defaultValue,enums,val,services});
+                }
+                return (ab) => ab.StringLiteral.setValue(val);
+            case 'Bytes':
+                if (val.includes('::')) {
+                    return typeCastingConvert({defaultValue,enums,val,services});
+                }
+                return (ab) => ab.StringLiteral.setValue(val);
         }
 
         if (val.includes('(') && val.includes(')')) {

--- a/packages/cli/src/actions/pull/provider/sqlite.ts
+++ b/packages/cli/src/actions/pull/provider/sqlite.ts
@@ -394,6 +394,10 @@ export const sqlite: IntrospectionProvider = {
                     return (ab) => ab.StringLiteral.setValue(strippedName);
                 }
                 return (ab) => ab.StringLiteral.setValue(val);
+            case 'Json':
+                return (ab) => ab.StringLiteral.setValue(val);
+            case 'Bytes':
+                return (ab) => ab.StringLiteral.setValue(val);
         }
 
         console.warn(`Unsupported default value type: "${defaultValue}" for field type "${fieldType}". Skipping default value.`);

--- a/packages/cli/src/actions/pull/utils.ts
+++ b/packages/cli/src/actions/pull/utils.ts
@@ -28,6 +28,10 @@ export function getAttribute(model: Model, attrName: string) {
         | undefined;
 }
 
+export function isDatabaseManagedAttribute(name: string) {
+    return ['@relation', '@id', '@unique'].includes(name) || name.startsWith('@db.');
+}
+
 export function getDatasource(model: Model) {
     const datasource = model.declarations.find((d) => d.$type === 'DataSource');
     if (!datasource) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -170,7 +170,7 @@ function createProgram() {
         .addOption(
             new Option('--quote <double|single>', 'set the quote style of generated schema files').default('single'),
         )
-        .addOption(new Option('--indent <number>', 'set the indentation of the generated schema files').default(4).argParser(parseInt))
+        .addOption(new Option('--indent <number>', 'set the indentation of the generated schema files').default(4))
         .action((options) => dbAction('pull', options));
 
     dbCommand

--- a/packages/cli/test/db/pull.test.ts
+++ b/packages/cli/test/db/pull.test.ts
@@ -1241,12 +1241,12 @@ describe('DB pull - SQL specific features', () => {
 
         const { workDir, schema } = await createProject(
             `model User {
-    id     Int    @id @default(autoincrement())
-    email  String @unique
-    status Status @default(ACTIVE)
+    id     Int        @id @default(autoincrement())
+    email  String     @unique
+    status UserStatus @default(ACTIVE)
 }
 
-enum Status {
+enum UserStatus {
     ACTIVE
     INACTIVE
     SUSPENDED
@@ -1262,13 +1262,13 @@ enum Status {
         runCli('db pull --indent 4', workDir);
 
         const restoredSchema = getSchema(workDir);
-        expect(restoredSchema).contains(`model User {
+        expect(restoredSchema).toContain(`model User {
     id     Int        @id @default(autoincrement())
     email  String     @unique
-    status Status @default(ACTIVE)
+    status UserStatus @default(ACTIVE)
 }`);
 
-        expect(restoredSchema).contains(`enum Status {
+        expect(restoredSchema).toContain(`enum UserStatus {
     ACTIVE
     INACTIVE
     SUSPENDED


### PR DESCRIPTION
- Retain data validation attributes (e.g., @email) on fields after
  introspection (#670)
- Preserve original declaration order of enums instead of moving them
  to the end of the schema file (#669)
- Preserve triple-slash comments above enum declarations (#669)
- Fixes Json defaults not resolves to string literal value.
- Fixes self-refencing models duplicates filed name

Fixes zenstackhq/zenstack#2342, fixes zenstackhq/zenstack#2341


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidates duplicate per-column enums during DB pulls to restore shared enums and clean schemas.

* **Improvements**
  * Better detection of database-managed attributes to reduce noisy diffs.
  * Preserves original declaration ordering and comments in generated schemas.
  * Improved handling of Json/Bytes default values across DB introspection.
  * Safer relation-name generation to avoid naming clashes during pulls.
  * Refined code-generation defaults for quote and indent; CLI indent parsing adjusted.

* **Tests**
  * Expanded tests covering enum consolidation, naming, ordering, and schema preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->